### PR TITLE
create-element-to-jsx-children: Convert .map calls into a JSXExpressi…

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -21,6 +21,8 @@ describe('create-element-to-jsx', () => {
 
     test('create-element-to-jsx', 'create-element-to-jsx-children');
 
+    test('create-element-to-jsx', 'create-element-to-jsx-children-map');
+
     test('create-element-to-jsx', 'create-element-to-jsx-spread');
 
     test('create-element-to-jsx', 'create-element-to-jsx-no-react');

--- a/test/create-element-to-jsx-children-map.js
+++ b/test/create-element-to-jsx-children-map.js
@@ -1,0 +1,7 @@
+var React = require('React');
+
+React.createElement(
+  'div',
+  null,
+  foo.map(function() {})
+);

--- a/test/create-element-to-jsx-children-map.output.js
+++ b/test/create-element-to-jsx-children-map.output.js
@@ -1,0 +1,3 @@
+var React = require('React');
+
+<div>{foo.map(function() {})}</div>;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -43,9 +43,13 @@ module.exports = function(file, api, options) {
     const children = node.value.arguments.slice(2).map((child, index) => {
       if (child.type === 'Literal') {
         return j.literal(child.value);
+      } else if (child.type === 'CallExpression' &&
+        child.callee.object.name === 'React' &&
+        child.callee.property.name === 'createElement') {
+        return convertNodeToJSX(node.get('arguments', index + 2));
+      } else {
+        return j.jsxExpressionContainer(child);
       }
-
-      return convertNodeToJSX(node.get('arguments', index + 2));
     });
 
     const openingElement = j.jsxOpeningElement(j.jsxIdentifier(elementName), attributes);


### PR DESCRIPTION
…onContainer

This didn't properly handle converting:
```
var React = require('React');

React.createElement(
  'div',
  null,
  foo.map(function() {})
);
```

to:

```
var React = require('React');

<div>{foo.map(function() {})}</div>;
```

Now it does! :)