### PR TITLE
create-element-to-jsx-children: Convert non primitive props to JSXExpressionContainer

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -17,6 +17,8 @@ describe('create-element-to-jsx', () => {
 
     test('create-element-to-jsx', 'create-element-to-jsx-props');
 
+    test('create-element-to-jsx', 'create-element-to-jsx-props-array');
+
     test('create-element-to-jsx', 'create-element-to-jsx-children-literal');
 
     test('create-element-to-jsx', 'create-element-to-jsx-children');

--- a/test/create-element-to-jsx-props-array.js
+++ b/test/create-element-to-jsx-props-array.js
@@ -1,0 +1,8 @@
+var React = require('react');
+
+var foo = React.createElement(
+  'div',
+  {
+    array: [],
+  }
+);

--- a/test/create-element-to-jsx-props-array.output.js
+++ b/test/create-element-to-jsx-props-array.output.js
@@ -1,0 +1,3 @@
+var React = require('react');
+
+var foo = <div array={[]} />;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -17,7 +17,7 @@ module.exports = function(file, api, options) {
         let value;
         if (propertyValueType === 'Literal') {
           value = j.literal(property.value.value);
-        } else if (propertyValueType === 'MemberExpression') {
+        } else {
           value = j.jsxExpressionContainer(property.value);
         }
 


### PR DESCRIPTION
Converting
```
var foo = React.createElement(
      'div',
      {
        array: []
      }
    );
```

to
```
var foo = <div array={[]} />;
```