### PR TITLE
create-element-to-jsx-children: Convert mixed strings to JSXText instead of Literal

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -27,6 +27,8 @@ describe('create-element-to-jsx', () => {
 
     test('create-element-to-jsx', 'create-element-to-jsx-children-map');
 
+    test('create-element-to-jsx', 'create-element-to-jsx-children-mixed-empty-string');
+
     test('create-element-to-jsx', 'create-element-to-jsx-spread');
 
     test('create-element-to-jsx', 'create-element-to-jsx-no-react');

--- a/test/create-element-to-jsx-children-mixed-empty-string.js
+++ b/test/create-element-to-jsx-children-mixed-empty-string.js
@@ -1,0 +1,11 @@
+var React = require('react');
+
+a = 'foo';
+
+React.createElement(
+  'div',
+  null,
+  a,
+  ' ',
+  a
+);

--- a/test/create-element-to-jsx-children-mixed-empty-string.output.js
+++ b/test/create-element-to-jsx-children-mixed-empty-string.output.js
@@ -1,0 +1,5 @@
+var React = require('react');
+
+a = 'foo';
+
+<div>{a} {a}</div>;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -41,8 +41,8 @@ module.exports = function(file, api, options) {
     const attributes = convertObjectExpressionToJSXAttributes(props);
 
     const children = node.value.arguments.slice(2).map((child, index) => {
-      if (child.type === 'Literal') {
-        return j.literal(child.value);
+      if (child.type === 'Literal' && typeof child.value === 'string') {
+        return j.jsxText(child.value);
       } else if (child.type === 'CallExpression' &&
         child.callee.object.name === 'React' &&
         child.callee.property.name === 'createElement') {


### PR DESCRIPTION
Based on #10 

This

```
React.createElement(
  'div',
  null,
  a,
  ' ',
  a
);
```

was getting transformed to

```
<div>{a}" "{a}</div>;
```

Now there are no unnecessary quotes.

However, I'm having a problem.
This
```
React.createElement(
  'div',
  null,
  ' lala '
);
```
is being converted to
```
<div>lala</div>;
```

Losing the padding spaces. It seems like `j.jsxText('  foo  ');` gets output as `foo`. `literal` has the same issue. So how can I make that case work?