### PR TITLE
create-element-to-jsx-children: Convert primitive attribute values properly

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -17,6 +17,8 @@ describe('create-element-to-jsx', () => {
 
     test('create-element-to-jsx', 'create-element-to-jsx-props');
 
+    test('create-element-to-jsx', 'create-element-to-jsx-props-array');
+
     test('create-element-to-jsx', 'create-element-to-jsx-children-literal');
 
     test('create-element-to-jsx', 'create-element-to-jsx-children');

--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -17,6 +17,8 @@ describe('create-element-to-jsx', () => {
 
     test('create-element-to-jsx', 'create-element-to-jsx-props');
 
+    test('create-element-to-jsx', 'create-element-to-jsx-props-boolean');
+
     test('create-element-to-jsx', 'create-element-to-jsx-props-array');
 
     test('create-element-to-jsx', 'create-element-to-jsx-children-literal');

--- a/test/create-element-to-jsx-props-array.js
+++ b/test/create-element-to-jsx-props-array.js
@@ -1,0 +1,8 @@
+var React = require('react');
+
+var foo = React.createElement(
+  'div',
+  {
+    array: [],
+  }
+);

--- a/test/create-element-to-jsx-props-array.output.js
+++ b/test/create-element-to-jsx-props-array.output.js
@@ -1,0 +1,3 @@
+var React = require('react');
+
+var foo = <div array={[]} />;

--- a/test/create-element-to-jsx-props-boolean.js
+++ b/test/create-element-to-jsx-props-boolean.js
@@ -1,0 +1,4 @@
+var React = require('React');
+
+var a = React.createElement('div', { a: true });
+var a = React.createElement('div', { a: 4 });

--- a/test/create-element-to-jsx-props-boolean.output.js
+++ b/test/create-element-to-jsx-props-boolean.output.js
@@ -1,0 +1,4 @@
+var React = require('React');
+
+var a = <div a={true} />;
+var a = <div a={4} />;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -17,7 +17,7 @@ module.exports = function(file, api, options) {
         let value;
         if (propertyValueType === 'Literal') {
           value = j.literal(property.value.value);
-        } else if (propertyValueType === 'MemberExpression') {
+        } else {
           value = j.jsxExpressionContainer(property.value);
         }
 

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -15,7 +15,7 @@ module.exports = function(file, api, options) {
         const propertyValueType = property.value.type;
 
         let value;
-        if (propertyValueType === 'Literal') {
+        if (propertyValueType === 'Literal' && typeof property.value.value === 'string') {
           value = j.literal(property.value.value);
         } else {
           value = j.jsxExpressionContainer(property.value);


### PR DESCRIPTION
Based on #11.

Primitive attribute types weren't being wrapped in `{ }`. The only thing that doesn't need to be wrapped in brackets are strings.