### PR TITLE
Allow for a callExpression as child that's not an element.

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -36,6 +36,8 @@ describe('create-element-to-jsx', () => {
     test('create-element-to-jsx', 'create-element-to-jsx-no-react');
 
     test('create-element-to-jsx', 'create-element-to-jsx-literal-prop');
+
+    test('create-element-to-jsx', 'create-element-to-jsx-call-as-children');
   });
 
 });

--- a/test/create-element-to-jsx-call-as-children.js
+++ b/test/create-element-to-jsx-call-as-children.js
@@ -1,0 +1,3 @@
+var React = require('react/addons');
+
+React.createElement('div', {}, foo());

--- a/test/create-element-to-jsx-call-as-children.output.js
+++ b/test/create-element-to-jsx-call-as-children.output.js
@@ -1,0 +1,3 @@
+var React = require('react/addons');
+
+<div>{foo()}</div>;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -55,6 +55,7 @@ module.exports = function(file, api, options) {
       if (child.type === 'Literal' && typeof child.value === 'string') {
         return j.jsxText(child.value);
       } else if (child.type === 'CallExpression' &&
+        child.callee.object &&
         child.callee.object.name === 'React' &&
         child.callee.property.name === 'createElement') {
         return convertNodeToJSX(node.get('arguments', index + 2));


### PR DESCRIPTION
The previous code assumed that all children that were of type
CallExpression were in fact calls on MemberExpressions. This fix makes
sure we also support other calls.