### PR TITLE
Support React.__spread/Object.assign in JSX transform

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -44,4 +44,16 @@ describe('create-element-to-jsx', () => {
     test('create-element-to-jsx', 'create-element-to-jsx-object-assign');
   });
 
+  it('raises when it does not recognize a property type', () => {
+    const jscodeshift = require('jscodeshift');
+    const transform = require('../../transforms/create-element-to-jsx');
+    const source = `
+      var React = require("react/addons");
+      React.createElement("foo", 1)
+    `;
+
+    expect(() => transform({source}, {jscodeshift}, {}))
+      .toThrow('Unexpected attribute of type "Literal"');
+  });
+
 });

--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -38,6 +38,10 @@ describe('create-element-to-jsx', () => {
     test('create-element-to-jsx', 'create-element-to-jsx-literal-prop');
 
     test('create-element-to-jsx', 'create-element-to-jsx-call-as-children');
+
+    test('create-element-to-jsx', 'create-element-to-jsx-react-spread');
+
+    test('create-element-to-jsx', 'create-element-to-jsx-object-assign');
   });
 
 });

--- a/test/create-element-to-jsx-object-assign.js
+++ b/test/create-element-to-jsx-object-assign.js
@@ -1,0 +1,7 @@
+var React = require('react/addons');
+
+React.createElement(Foo, Object.assign({
+  'foo': 'bar'
+}, props, {
+  'bar': 'foo'
+}));

--- a/test/create-element-to-jsx-object-assign.output.js
+++ b/test/create-element-to-jsx-object-assign.output.js
@@ -1,0 +1,3 @@
+var React = require('react/addons');
+
+<Foo foo="bar" {...props} bar="foo" />;

--- a/test/create-element-to-jsx-react-spread.js
+++ b/test/create-element-to-jsx-react-spread.js
@@ -1,0 +1,7 @@
+var React = require('react/addons');
+
+React.createElement(Foo, React.__spread({
+  'foo': 'bar'
+}, props, {
+  'bar': 'foo'
+}));

--- a/test/create-element-to-jsx-react-spread.output.js
+++ b/test/create-element-to-jsx-react-spread.output.js
@@ -1,0 +1,3 @@
+var React = require('react/addons');
+
+<Foo foo="bar" {...props} bar="foo" />;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -17,7 +17,7 @@ module.exports = function(file, api, options) {
     if (expression.type === 'Identifier') {
       return [j.jsxSpreadAttribute(expression)];
     } else if (isReactSpread || isObjectAssign) {
-      var jsxAttributes = [];
+      const jsxAttributes = [];
 
       expression.arguments.forEach((expression) =>
         jsxAttributes.push(...convertExpressionToJSXAttributes(expression))

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -3,63 +3,61 @@ module.exports = function(file, api, options) {
   const root = j(file.source);
   const ReactUtils = require('./utils/ReactUtils')(j);
 
-  const convertObjectExpressionToJSXAttributes = (objectExpression) => {
-    if (objectExpression.type === 'Identifier') {
-      return [j.jsxSpreadAttribute(objectExpression)];
-    }
+  const convertExpressionToJSXAttributes = (expression) => {
+    const isReactSpread = expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.object.name === 'React' &&
+      expression.callee.property.name === '__spread';
 
-    const isReactSpread = objectExpression.type === 'CallExpression' &&
-      objectExpression.callee.type === 'MemberExpression' &&
-      objectExpression.callee.object.name === 'React' &&
-      objectExpression.callee.property.name === '__spread';
+    const isObjectAssign = expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.object.name === 'Object' &&
+      expression.callee.property.name === 'assign';
 
-    const isObjectAssign = objectExpression.type === 'CallExpression' &&
-      objectExpression.callee.type === 'MemberExpression' &&
-      objectExpression.callee.object.name === 'Object' &&
-      objectExpression.callee.property.name === 'assign';
-
-    if (isReactSpread || isObjectAssign) {
+    if (expression.type === 'Identifier') {
+      return [j.jsxSpreadAttribute(expression)];
+    } else if (isReactSpread || isObjectAssign) {
       var jsxAttributes = [];
 
-      objectExpression.arguments.forEach((objectExpression) =>
-        jsxAttributes.push(...convertObjectExpressionToJSXAttributes(objectExpression))
+      expression.arguments.forEach((expression) =>
+        jsxAttributes.push(...convertExpressionToJSXAttributes(expression))
       );
 
       return jsxAttributes;
-    }
+    } else if (expression.type === 'ObjectExpression') {
+      const attributes = expression.properties.map((property) => {
+        if (property.type === 'SpreadProperty') {
+          return j.jsxSpreadAttribute(property.argument);
+        }  else if (property.type === 'Property') {
+          const propertyValueType = property.value.type;
 
-    if (!objectExpression.properties) {
+          let value;
+          if (propertyValueType === 'Literal' && typeof property.value.value === 'string') {
+            value = j.literal(property.value.value);
+          } else {
+            value = j.jsxExpressionContainer(property.value);
+          }
+
+          let propertyKeyName;
+          if (property.key.type === 'Literal') {
+            propertyKeyName = property.key.value;
+          } else {
+            propertyKeyName = property.key.name;
+          }
+
+          return j.jsxAttribute(
+            j.jsxIdentifier(propertyKeyName),
+            value
+          );
+        }
+      });
+
+      return attributes;
+    } else if (expression.type === 'Literal' && expression.value === null) {
       return [];
+    } else {
+      throw new Error(`Unexpected attribute of type "${expression.type}"`);
     }
-
-    const attributes = objectExpression.properties.map((property) => {
-      if (property.type === 'SpreadProperty') {
-        return j.jsxSpreadAttribute(property.argument);
-      }  else if (property.type === 'Property') {
-        const propertyValueType = property.value.type;
-
-        let value;
-        if (propertyValueType === 'Literal' && typeof property.value.value === 'string') {
-          value = j.literal(property.value.value);
-        } else {
-          value = j.jsxExpressionContainer(property.value);
-        }
-
-        let propertyKeyName;
-        if (property.key.type === 'Literal') {
-          propertyKeyName = property.key.value;
-        } else {
-          propertyKeyName = property.key.name;
-        }
-
-        return j.jsxAttribute(
-          j.jsxIdentifier(propertyKeyName),
-          value
-        );
-      }
-    });
-
-    return attributes;
   };
 
   const convertNodeToJSX = (node) => {
@@ -69,7 +67,7 @@ module.exports = function(file, api, options) {
     const elementName = elementType === 'Literal' ? args[0].value : args[0].name;
     const props = args[1];
 
-    const attributes = convertObjectExpressionToJSXAttributes(props);
+    const attributes = convertExpressionToJSXAttributes(props);
 
     const children = node.value.arguments.slice(2).map((child, index) => {
       if (child.type === 'Literal' && typeof child.value === 'string') {

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -8,6 +8,26 @@ module.exports = function(file, api, options) {
       return [j.jsxSpreadAttribute(objectExpression)];
     }
 
+    const isReactSpread = objectExpression.type === 'CallExpression' &&
+      objectExpression.callee.type === 'MemberExpression' &&
+      objectExpression.callee.object.name === 'React' &&
+      objectExpression.callee.property.name === '__spread';
+
+    const isObjectAssign = objectExpression.type === 'CallExpression' &&
+      objectExpression.callee.type === 'MemberExpression' &&
+      objectExpression.callee.object.name === 'Object' &&
+      objectExpression.callee.property.name === 'assign';
+
+    if (isReactSpread || isObjectAssign) {
+      var jsxAttributes = [];
+
+      objectExpression.arguments.forEach((objectExpression) =>
+        jsxAttributes.push(...convertObjectExpressionToJSXAttributes(objectExpression))
+      );
+
+      return jsxAttributes;
+    }
+
     if (!objectExpression.properties) {
       return [];
     }


### PR DESCRIPTION
While reviewing the output of the transform I noticed that the transform lost all attributes for elements that use the `React.__spread` helper. I decided to fix this and make the transform throw an error when it doesn't recognise a certain attribute. This way we can be more sure that things don't fall through.