### PR TITLE
Add info about requiring React

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ APIs.
   * `jscodeshift -t <codemod-script> <file>`
   * Use the `-d` option for a dry-run and use `-p` to print the output
     for comparison
+  * *Note:* React has to be required within the source files (e.g. `var React = require('react')`), otherwise the files will be ignored even if they have calls to a global React variable. 
 
 ### Included Scripts
 


### PR DESCRIPTION
If React is not required, the transformations ignore the target files. Added a note to clarify this issue.