### PR TITLE
Make sure less-than and great-than characters are properly encoded.

### DIFF
--- a/test/__tests__/create-element-to-jsx-test.js
+++ b/test/__tests__/create-element-to-jsx-test.js
@@ -48,6 +48,8 @@ describe('create-element-to-jsx', () => {
     test('create-element-to-jsx', 'create-element-to-jsx-call-expression-as-prop');
 
     test('create-element-to-jsx', 'create-element-to-jsx-allow-member-expression');
+
+    test('create-element-to-jsx', 'create-element-to-jsx-gt-lt-entities');
   });
 
   it('raises when it does not recognize a property type', () => {

--- a/test/create-element-to-jsx-gt-lt-entities.js
+++ b/test/create-element-to-jsx-gt-lt-entities.js
@@ -1,0 +1,3 @@
+var React = require('React');
+
+React.createElement('div', null, '\x3C\x3E');

--- a/test/create-element-to-jsx-gt-lt-entities.output.js
+++ b/test/create-element-to-jsx-gt-lt-entities.output.js
@@ -1,0 +1,3 @@
+var React = require('React');
+
+<div>&lt;&gt;</div>;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -4,13 +4,8 @@ module.exports = function(file, api, options) {
   const ReactUtils = require('./utils/ReactUtils')(j);
   const encodeJSXTextValue = value =>
     value
-      .replace(new RegExp('(?:<|>)', 'g'), match => {
-        if (match === '<') {
-          return '&lt;';
-        } else {
-          return '&gt;';
-        }
-      });
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
 
   const convertExpressionToJSXAttributes = (expression) => {
     const isReactSpread = expression.type === 'CallExpression' &&

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -2,6 +2,15 @@ module.exports = function(file, api, options) {
   const j = api.jscodeshift;
   const root = j(file.source);
   const ReactUtils = require('./utils/ReactUtils')(j);
+  const encodeJSXTextValue = value =>
+    value
+      .replace(new RegExp('(?:<|>)', 'g'), match => {
+        if (match === '<') {
+          return '&lt;';
+        } else {
+          return '&gt;';
+        }
+      });
 
   const convertExpressionToJSXAttributes = (expression) => {
     const isReactSpread = expression.type === 'CallExpression' &&
@@ -89,7 +98,7 @@ module.exports = function(file, api, options) {
 
     const children = node.value.arguments.slice(2).map((child, index) => {
       if (child.type === 'Literal' && typeof child.value === 'string') {
-        return j.jsxText(child.value);
+        return j.jsxText(encodeJSXTextValue(child.value));
       } else if (child.type === 'CallExpression' &&
         child.callee.object &&
         child.callee.object.name === 'React' &&


### PR DESCRIPTION
Previously the transform would translate

```
React.createElement("div", null, "\x3C");
```

To

```
<div><</div>;
```

This PR fixes this by translating `<>` to `&lt;&gt;`.