### PR TITLE
@jnwng

### DIFF
--- a/transforms/class.js
+++ b/transforms/class.js
@@ -354,8 +354,15 @@ module.exports = (file, api, options) => {
     getInitialState,
     autobindFunctions,
     comments
-  ) =>
-    withComments(j.classDeclaration(
+  ) => {
+    console.log([].concat(
+      createConstructor(
+        getInitialState,
+        autobindFunctions
+      ),
+      properties
+    ));
+    return withComments(j.classDeclaration(
       name ? j.identifier(name) : null,
       j.classBody(
         [].concat(
@@ -372,6 +379,7 @@ module.exports = (file, api, options) => {
         false
       )
     ), {comments});
+  }
 
   const createStaticAssignment = (name, staticProperty) =>
     withComments(j.expressionStatement(
@@ -470,8 +478,9 @@ module.exports = (file, api, options) => {
       path = j(classPath).closest(j.VariableDeclaration);
     }
 
-    const properties =
-      (type == 'exportDefault') ? createStaticClassProperties(statics) : [];
+    // const properties =
+    //  (type == 'exportDefault') ? createStaticClassProperties(statics) : [];
+    const properties = createStaticClassProperties(statics);
 
     path.replaceWith(
       createESClass(
@@ -488,11 +497,14 @@ module.exports = (file, api, options) => {
         staticName,
         statics
       );
+      /*
       if (type == 'moduleExports') {
         root.get().value.program.body.push(...staticAssignments);
       } else {
         path.insertAfter(staticAssignments.reverse());
       }
+      */
+      path.insertAfter(staticAssignments.reverse());
     }
   };
 

--- a/transforms/utils/ReactUtils.js
+++ b/transforms/utils/ReactUtils.js
@@ -41,7 +41,8 @@ module.exports = function(j) {
   const hasReact = path => (
     hasModule(path, 'React') ||
     hasModule(path, 'react') ||
-    hasModule(path, 'react/addons')
+    hasModule(path, 'react/addons') ||
+    hasModule(path, 'react-with-addons')  // Required for Coursera specific naming conventions.
   );
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
This adjusts the class.js codemod to do es7 static class properties. Not sure how to test
this since it requires external libraries so i was unable to use the in browser analyzer.
Trying to see if facebook has an atom plugin or something.

Future improvements:
- Fat arrow function instead of .bind(this) in constructor
- Sorting of functions based on our linter configuration.