### PR TITLE
Fix linter warning in a test file

### DIFF
--- a/test/create-element-to-jsx-allow-member-expression.js
+++ b/test/create-element-to-jsx-allow-member-expression.js
@@ -1,3 +1,3 @@
 var React = require('react/addons');
 
-React.createElement(React.addons.CSSTransitionGroup, null, "");
+React.createElement(React.addons.CSSTransitionGroup, null, '');


### PR DESCRIPTION
When running tests locally, I noticed that eslint warned here. Using
single quotes satisfies the linter in this case.