### PR TITLE
take method ordering in sort-comp as an option

### DIFF
--- a/test/sort-comp-test2.js
+++ b/test/sort-comp-test2.js
@@ -16,7 +16,7 @@ class MyComponent extends React.Component {
   }
 
   static someStaticThing() {
-    // should come first
+    // should bundle with other statics
   }
 
   renderFoo() {
@@ -25,6 +25,10 @@ class MyComponent extends React.Component {
 
   renderBar() {
     // should come before renderFoo
+  }
+
+  static aStaticThing() {
+    // should come first
   }
 
   myOwnMethod(foo) {

--- a/test/sort-comp-test2.output.js
+++ b/test/sort-comp-test2.output.js
@@ -4,8 +4,12 @@ const propTypes = {};
 
 // comment above class
 class MyComponent extends React.Component {
-  static someStaticThing() {
+  static aStaticThing() {
     // should come first
+  }
+
+  static someStaticThing() {
+    // should bundle with other statics
   }
 
   // comment on componentDidMount


### PR DESCRIPTION
Also simplifies the logic. I originally based it off https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/sort-comp.js, but it doesn't need to be nearly as complex because it doesn't have to give useful error output.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/reactjs/react-codemod/33)
<!-- Reviewable:end -->
