### PR TITLE
Fix create-element-to-jsx failing when props argument is missing

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-no-props-arg.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-no-props-arg.input.js
@@ -1,0 +1,4 @@
+var React = require('React');
+
+var a = React.createElement(Foo);
+var b = React.createElement('div');

--- a/transforms/__testfixtures__/create-element-to-jsx-no-props-arg.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-no-props-arg.output.js
@@ -1,0 +1,4 @@
+var React = require('React');
+
+var a = <Foo />;
+var b = <div />;

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -126,6 +126,12 @@ describe('create-element-to-jsx', () => {
     null,
     'create-element-to-jsx-gt-lt-entities'
   );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-no-props-arg'
+  );
 
   it('throws when it does not recognize a property type', () => {
     const jscodeshift = require('jscodeshift');

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -101,7 +101,7 @@ module.exports = function(file, api, options) {
     const jsxIdentifier = jsxIdentifierFor(args[0]);
     const props = args[1];
 
-    const attributes = convertExpressionToJSXAttributes(props);
+    const attributes = props ? convertExpressionToJSXAttributes(props) : [];
 
     const children = node.value.arguments.slice(2).map((child, index) => {
       if (child.type === 'Literal' && typeof child.value === 'string') {


### PR DESCRIPTION
`React.createElement(Component)`, without the second `props` argument,
was failing with `TypeError: Cannot read property 'type' of undefined`
error. As `React.createElement()` allows emitting the `props` argument
altogether as far as I have understood, the codemod shouldn't fail when
props argument is indeed missing.