### PR TITLE
Add "npm install" to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ APIs.
   * `npm install -g jscodeshift`
   * `git clone https://github.com/reactjs/react-codemod.git` or download a zip file
     from `https://github.com/reactjs/react-codemod/archive/master.zip`
+  * Run `npm install` in the react-codemod directory
   * `jscodeshift -t <codemod-script> <path>`
   * Use the `-d` option for a dry-run and use `-p` to print the output
     for comparison


### PR DESCRIPTION
Tried running the sort-comp without npm installing first and got 

```
ERR /client/scripts/myFile.js Transformation error
Error: Cannot find module 'eslint'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at getMethodsOrderFromEslint (/tmp/react-codemod/transforms/sort-comp.js:179:21)
    at getMethodsOrder (/tmp/react-codemod/transforms/sort-comp.js:194:8)
    at module.exports (/tmp/react-codemod/transforms/sort-comp.js:39:24)
```