### PR TITLE
Dont put regexes in quotes

### DIFF
--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -122,10 +122,10 @@ const defaultMethodsOrder = [
   'componentWillUpdate',
   'componentDidUpdate',
   'componentWillUnmount',
-  '/^on.+$/',
-  '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
+  /^on.+$/,
+  /^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/,
   'everything-else',
-  '/^render.+$/',
+  /^render.+$/,
   'render',
 ];
 


### PR DESCRIPTION
The current file actually sorts the methods in the wrong order in Node 6.2.0.