### PR TITLE
56: identify components with refs as impure

### DIFF
--- a/transforms/__testfixtures__/pure-component.input.js
+++ b/transforms/__testfixtures__/pure-component.input.js
@@ -21,4 +21,14 @@ class Impure extends React.Component {
   }
 }
 
+class ImpureWithRef extends React.Component {
+  render() {
+    return (
+      <div>
+        <span ref="spanasaurus" />
+      </div>
+    );
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component.output.js
+++ b/transforms/__testfixtures__/pure-component.output.js
@@ -19,4 +19,14 @@ class Impure extends React.Component {
   }
 }
 
+class ImpureWithRef extends React.Component {
+  render() {
+    return (
+      <div>
+        <span ref="spanasaurus" />
+      </div>
+    );
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/pure-component.js
+++ b/transforms/pure-component.js
@@ -36,6 +36,16 @@ module.exports = function(file, api, options) {
       .filter(p => !isRenderMethod(p.value))
       .size() === 0;
 
+  const hasRefs = path =>
+    j(path)
+      .find(j.JSXAttribute, {
+        name: {
+          type: 'JSXIdentifier',
+          name: 'ref',
+        },
+      })
+      .size() > 0;
+
   const THIS_PROPS = {
     object: {
       type: 'ThisExpression',
@@ -82,7 +92,7 @@ module.exports = function(file, api, options) {
 
   const pureClasses = ReactUtils.findReactES6ClassDeclaration(f)
     .filter(path => {
-      const isPure = onlyHasRenderMethod(path);
+      const isPure = onlyHasRenderMethod(path) && !hasRefs(path);
       if (!isPure && !silenceWarnings) {
         reportSkipped(path);
       }
@@ -109,4 +119,3 @@ module.exports = function(file, api, options) {
 
   return f.toSource(printOptions);
 };
-


### PR DESCRIPTION
This fixes #56, skips over components that render with a `ref`.