### PR TITLE
Document bug in create-element-to-jsx, add Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Converts calls to `React.createElement` into JSX elements.
 jscodeshift -t react-codemod/transforms/create-element-to-jsx.js <path>
 ```
 
+Note that this script will **destroy comments** within `createElement` usages,
+so you should manually check for any lost comments after running the
+transform.
+
 #### `findDOMNode`
 
 Updates `this.getDOMNode()` or `this.refs.foo.getDOMNode()` calls inside of
@@ -155,3 +159,13 @@ through the `printOptions` command line argument
 ```sh
 jscodeshift -t transform.js <path> --printOptions='{"quote":"double"}'
 ```
+
+### Support and Contributing
+
+The scripts in this repository are provided in the hope that they are useful,
+but they are not officially maintained, and we generally will not fix
+community-reported issues. They are a collection of scripts that were previously
+used internally within Facebook or were contributed by the community, and we
+rely on community contributions to fix any issues discovered or make any
+improvements. If you want to contribute, you're welcome to submit a pull
+request.


### PR DESCRIPTION
As mentioned in #59, the `create-element-to-jsx` codemod can destroy comments,
so leave a warning in the docs so people know to be careful.

Also add a "Support and Contributing" section at the bottom of the README that
briefly describes the state and purpose of the repo and how contributions are
handled.