### PR TITLE
Make create-element-to-jsx properly transfer comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ Converts calls to `React.createElement` into JSX elements.
 jscodeshift -t react-codemod/transforms/create-element-to-jsx.js <path>
 ```
 
-Note that this script will **destroy comments** within `createElement` usages,
-so you should manually check for any lost comments after running the
-transform.
-
 #### `findDOMNode`
 
 Updates `this.getDOMNode()` or `this.refs.foo.getDOMNode()` calls inside of

--- a/transforms/__testfixtures__/create-element-to-jsx-preserve-comments.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-preserve-comments.input.js
@@ -1,0 +1,38 @@
+var React = require('react');
+
+const render = () => {
+  return /*1*/React/*2*/./*3*/createElement/*4*/(
+    /*5*/'div'/*6*/,/*7*/
+    {
+      /*8*/className/*9*/: /*10*/'foo'/*11*/,/*12*/
+      /*13*/onClick/*14*/:/*15*/ this.handleClick/*16*/, //17
+    }/*18*/,
+    /*19*/React.createElement(/*20*/TodoList/*21*/./*22*/Item/*23*/)/*24*/, //25
+    React.createElement(
+      'span',
+      /*26*/getProps()/*27*/
+    ),
+    React.createElement('input', /*28*/null/*29*/)
+  );
+};
+
+const render2 = () => {
+  return React.createElement(
+    'div', {
+      className: 'foo',  // Prop comment.
+    },
+    'hello' // Child string comment.
+  );
+};
+
+const render3 = () => {
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('span') // Child element comment.
+  );
+};
+
+const render4 = () => {
+  return React.createElement(Foo, {/* No props to see here! */});
+};

--- a/transforms/__testfixtures__/create-element-to-jsx-preserve-comments.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-preserve-comments.output.js
@@ -1,0 +1,26 @@
+var React = require('react');
+
+const render = () => {
+  return /*1*//*4*//*2*//*3*/</*5*/div/*6*//*7*//*18*/
+    /*8*/className/*9*/=/*10*/"foo"/*11*/
+    /*12*/
+    /*13*///17
+    onClick/*14*/={/*15*/ this.handleClick}/*16*/>{/*19*///25
+    </*20*/TodoList/*21*/./*22*/Item/*23*/ />/*24*/}<span {.../*26*/getProps()/*27*/} /><input /*28*//*29*/ /></div>;
+};
+
+const render2 = () => {
+  return <div
+    // Prop comment.
+    className="foo">{// Child string comment.
+    'hello'}</div>;
+};
+
+const render3 = () => {
+  return <div>{// Child element comment.
+    <span />}</div>;
+};
+
+const render4 = () => {
+  return <Foo/* No props to see here! */ />;
+};

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -132,6 +132,12 @@ describe('create-element-to-jsx', () => {
     null,
     'create-element-to-jsx-no-props-arg'
   );
+  defineTest(
+      __dirname,
+      'create-element-to-jsx',
+      null,
+      'create-element-to-jsx-preserve-comments'
+  );
 
   it('throws when it does not recognize a property type', () => {
     const jscodeshift = require('jscodeshift');


### PR DESCRIPTION
Originally filed as #59.

Some non-obvious aspects of this change:

* For the main test, I put a comment between nearly every token. The generated
  output is really messy, but the main important thing is that every comment in
  the input appears somewhere in the output.
* For closing tags, I had to make a copy of the JSXIdentifier without any
  comments. Otherwise, `React.createElement('div' /*foo*/, null, ' ')` would
  become `<div /*foo*/> </div /*foo*/>`.
* I had to change the signature of `convertExpressionToJSXAttributes` to also
  return an `extraComments` value for any comments that didn't have an obvious
  attribute to attach to. This is also necessary since there might be no
  attributes, but still some comments.
* JSXText elements seem to ignore any comments you attach to them, so I had to
  just use the default behavior of a JSXExpressionContainer for any child
  strings that have comments.
* Attaching comments to JSXElement nodes that are children of other JSXElement
  nodes causes the comment to be incorrectly printed as a child string, e.g.
  `<div><span />/*a comment*/</div>`. To avoid this, whenever the script
  generates a child JSXElement, it wraps it in a JSXExpressionContainer if there
  are any comments.
* It looks like some comments can be neither leading nor trailing (e.g.
  `{/*foo*/}`, and that makes them not print when they're transferred to other
  nodes. So in some cases I had to explicitly set the `leading` and `trailing`
  booleans when transferring comments. This also makes the comment positioning
  look nicer in some situations.