### PR TITLE
Initial version of manual bind to arrow function

### DIFF
--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow1.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow1.input.js
@@ -1,0 +1,7 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    this.onClick = this.onClick.bind(this);
+  }
+  onClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow1.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow1.output.js
@@ -1,0 +1,3 @@
+class Component extends React.Component {
+  onClick = () => { };
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow2.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow2.input.js
@@ -1,0 +1,19 @@
+class SomeName extends React.Component {
+  _onChange: Function;
+
+  constructor(props: Object) {
+    super(props);
+    this._onChange = this._onChange.bind(this);
+    if (!this.props.something.somePreference) {
+      this._onChange(SomeConstantsOptions.SOME_CONSTANT);
+    }
+  }
+
+  /* Some comment */
+  _onChange(value: String): void {
+    Dispatcher.handleViewAction({
+      type: SomeConstantsOptions.SOME_CONSTANT,
+      payload: value,
+    });
+  }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow2.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow2.output.js
@@ -1,0 +1,18 @@
+class SomeName extends React.Component {
+  _onChange: Function;
+
+  constructor(props: Object) {
+    super(props);
+    if (!this.props.something.somePreference) {
+      this._onChange(SomeConstantsOptions.SOME_CONSTANT);
+    }
+  }
+
+  /* Some comment */
+  _onChange = (value: String): void => {
+    Dispatcher.handleViewAction({
+      type: SomeConstantsOptions.SOME_CONSTANT,
+      payload: value,
+    });
+  };
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow3.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow3.input.js
@@ -1,0 +1,7 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    this.onClick = this.onClick.bind(this);
+  }
+  notOnClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow4.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow4.input.js
@@ -1,0 +1,7 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    (this: any).onClick = this.onClick.bind(this);
+  }
+  onClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow4.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow4.output.js
@@ -1,0 +1,3 @@
+class Component extends React.Component {
+  onClick = () => { };
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow5.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow5.input.js
@@ -1,0 +1,8 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    const self: any = this;
+    self.onClick = this.onClick.bind(this);
+  }
+  onClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow5.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow5.output.js
@@ -1,0 +1,3 @@
+class Component extends React.Component {
+  onClick = () => { };
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow6.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow6.input.js
@@ -1,0 +1,10 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    const self: any = this;
+    self._onMapResize = debounceCore(this._onMapResize.bind(this), 100);
+    self.onClick = this.onClick.bind(this);
+  }
+  onClick() { }
+  onMapResize() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow6.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow6.output.js
@@ -1,0 +1,9 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    const self: any = this;
+    self._onMapResize = debounceCore(this._onMapResize.bind(this), 100);
+  }
+  onClick = () => { };
+  onMapResize() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow7.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow7.input.js
@@ -1,0 +1,10 @@
+class SomeClass {
+  constructor() {
+    (this: any)._isLoaded = false;
+    (this: any).isLoaded = this.isLoaded.bind(this);
+  }
+
+  isLoaded(): boolean {
+    return this._isLoaded;
+  }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow7.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow7.output.js
@@ -1,0 +1,9 @@
+class SomeClass {
+  constructor() {
+    (this: any)._isLoaded = false;
+  }
+
+  isLoaded = (): boolean => {
+    return this._isLoaded;
+  };
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow8.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow8.input.js
@@ -1,0 +1,7 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    this.onClick = this.onClick.bind(this);
+  }
+  async onClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow8.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow8.output.js
@@ -1,0 +1,3 @@
+class Component extends React.Component {
+  onClick = async () => { };
+}

--- a/transforms/__tests__/manual-bind-to-arrow-test.js
+++ b/transforms/__tests__/manual-bind-to-arrow-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+var TESTS = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+];
+
+TESTS.forEach(test => {
+  defineTest(
+    __dirname,
+    'manual-bind-to-arrow',
+    {flow: true},
+    'manual-bind-to-arrow/manual-bind-to-arrow' + test
+  );
+});

--- a/transforms/manual-bind-to-arrow.js
+++ b/transforms/manual-bind-to-arrow.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ * class Component extends React.Component {
+ *   constructor() { this.onClick = this.onClick.bind(this); }
+ *   onClick() { }
+ * }
+ *
+ * -->
+ *
+ * class Component extends React.Component {
+ *   onClick = () => { }
+ * }
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+
+  var root = j(file.source);
+
+  // Helper functions to transform a method declaration to an arrow function
+  // By default recast drops comments and jscodeshift doesn't have a way to
+  // set the return type in the convenience method. Otherwise we would have
+  // inlined all those.
+  function withComments(to, from) {
+    to.comments = from.comments;
+    return to;
+  }
+
+  function createArrowFunctionExpression(fn) {
+    var arrowFunc = j.arrowFunctionExpression(
+      fn.params,
+      fn.body,
+      false
+    );
+
+    arrowFunc.returnType = fn.returnType;
+    arrowFunc.defaults = fn.defaults;
+    arrowFunc.rest = fn.rest;
+    arrowFunc.async = fn.async;
+
+    return arrowFunc;
+  }
+
+  function createArrowProperty(prop) {
+    return withComments(j.classProperty(
+      j.identifier(prop.key.name),
+      createArrowFunctionExpression(prop.value),
+      null,
+      false
+    ), prop);
+  }
+
+  var hasChanged = false;
+  var transform = root
+    .find(j.AssignmentExpression)
+    .forEach(path => {
+
+      // Check that the englobing function is constructor
+      var methodPath = path;
+      while (methodPath &&
+             (methodPath.node.type !== 'MethodDefinition' ||
+              methodPath.node.kind !== 'constructor')) {
+        methodPath = methodPath.parentPath;
+      }
+      if (!methodPath) {
+        return;
+      }
+
+      // Check that it looks like
+      // this.method = this.method.bind(this);
+      // or
+      // (this: any).method = this.method.bind(this);
+      // or
+      // self.method = this.method.bind(this);
+      if (!(
+        path.node.left.type === 'MemberExpression' &&
+        (
+          // this
+          path.node.left.object.type === 'ThisExpression' ||
+          // self
+          path.node.left.object.type === 'Identifier' &&
+          path.node.left.object.name === 'self' ||
+          // (this: any)
+          path.node.left.object.type === 'TypeCastExpression' &&
+          path.node.left.object.expression.type === 'ThisExpression'
+        ) &&
+        path.node.left.property.type === 'Identifier' &&
+        path.node.right.type === 'CallExpression' &&
+        path.node.right.callee.type === 'MemberExpression' &&
+        path.node.right.callee.property.type === 'Identifier' &&
+        path.node.right.callee.property.name === 'bind' &&
+        path.node.right.callee.object.type === 'MemberExpression' &&
+        path.node.right.callee.object.property.type === 'Identifier' &&
+        path.node.right.callee.object.object.type === 'ThisExpression' &&
+        path.node.left.property.name === path.node.right.callee.object.property.name &&
+        true
+      )) {
+        return;
+      }
+
+      // Find the method() declaration and replace it with an arrow function
+      var methodName = path.node.left.property.name;
+      var methods = root
+        .find(j.MethodDefinition)
+        .filter(path =>
+          path.node.key.type === 'Identifier' &&
+          path.node.key.name === methodName
+        );
+
+      // Do not remove the binding if there's no corresponding method to turn
+      // into an arrow function
+      if (methods.size() === 0) {
+        return;
+      }
+      methods
+        .replaceWith(path =>
+          createArrowProperty(path.node)
+        );
+
+      // Remove the line
+      // this.method = this.method.bind(this);
+      j(path.parentPath).remove();
+
+      var selfCount = j(methodPath)
+        .find(j.Identifier, {name: 'self'})
+        .size();
+      if (selfCount === 1) {
+        // Remove the line
+        // const self: any = this;
+        // If self is present somewhere else in the method, then it is
+        // not safe to do.
+        j(methodPath)
+          .find(j.VariableDeclaration)
+          .filter(path =>
+            j(path).find(j.Identifier, {name: 'self'}).size() === 1
+          )
+          .remove();
+      }
+
+      // If we delete everything from the constructor but the super() call,
+      // then delete the entire constructor.
+      var canDeleteConstructor = true;
+      methodPath.node.value.body.body.forEach(node => {
+        if (
+          !node ||
+          node.type === 'ExpressionStatement' &&
+          node.expression.type === 'CallExpression' &&
+          (
+            // babylon parser
+            node.expression.callee.type === 'Super' ||
+            // flow parser
+            node.expression.callee.type === 'Identifier' &&
+            node.expression.callee.name === 'super'
+          )
+        ) {
+          return;
+        }
+        canDeleteConstructor = false;
+      });
+      if (canDeleteConstructor) {
+        j(methodPath).remove();
+      }
+
+      hasChanged++;
+    });
+
+  if (hasChanged) {
+    return transform.toSource();
+  }
+  return null;
+}
+
+// module.exports.parser = 'flow';


### PR DESCRIPTION
This converts the manual bind to an arrow property initializer function.

It works for the base case `this.method = this.method.bind(this);`, two other patterns that I've seen in the codebase that should be codemodded as well in a subsequent version

- `(this: any).method = this.method.bind(this)`
- `const self = (this: any); self.method = this.method.bind(this)`

Test Plan:
npm t

I haven't tried it on the codebase yet, just want to get early feedback