### PR TITLE
sort-comp instantiates regex from eslintrc properly

### DIFF
--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -146,7 +146,8 @@ function selectorMatches(selector, method) {
   const selectorIsRe = regExpRegExp.test(selector);
 
   if (selectorIsRe) {
-    const selectorRe = new RegExp(selector);
+    const match = selector.match(regExpRegExp);
+    const selectorRe = new RegExp(match[1], match[2]);
     return selectorRe.test(methodName);
   }
 

--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -122,10 +122,10 @@ const defaultMethodsOrder = [
   'componentWillUpdate',
   'componentDidUpdate',
   'componentWillUnmount',
-  /^on.+$/,
-  /^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/,
+  '/^on.+$/',
+  '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
   'everything-else',
-  /^render.+$/,
+  '/^render.+$/',
   'render',
 ];
 


### PR DESCRIPTION
This fixes the issue where react/sort-comp eslint rules such as `"/^render+.$/"` are incorrectly converted to `/\/^render.+$\//` rather than `/^render.+$/`