### PR TITLE
Add documentation for manual-bind-to-arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ to `getDOMNode` and then manually go through the remaining calls.
 jscodeshift -t react-codemod/transforms/findDOMNode.js <path>
 ```
 
+#### `manual-bind-to-arrow`
+
+Converts manual function bindings in a class (e.g., `this.f = this.f.bind(this)`) to arrow property initializer functions (e.g., `f = () => {}`).
+
+```sh
+jscodeshift -t react-codemod/transforms/manual-bind-to-arrow.js <path>
+```
+
 #### `pure-component`
 
 ```sh


### PR DESCRIPTION
Hey reactjs team,

I came to the manual-bind-to-arrow transform following a tweet from Sebastian. I ran it and it worked fantastically on my project. So I took a moment to add some brief documentation to the README. 

Any feedback would be welcome.
