### PR TITLE
Skip incorrectly-capitalized cases in create-element-to-jsx

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.input.js
@@ -1,0 +1,9 @@
+var React = require('React');
+
+React.createElement(Foo);
+React.createElement(foo);
+React.createElement('Foo');
+React.createElement('foo');
+React.createElement(_foo);
+React.createElement('_foo');
+React.createElement(foo.bar);

--- a/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.output.js
@@ -1,0 +1,9 @@
+var React = require('React');
+
+<Foo />;
+React.createElement(foo);
+React.createElement('Foo');
+<foo />;
+<_foo />;
+React.createElement('_foo');
+<foo.bar />;

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -133,10 +133,16 @@ describe('create-element-to-jsx', () => {
     'create-element-to-jsx-no-props-arg'
   );
   defineTest(
-      __dirname,
-      'create-element-to-jsx',
-      null,
-      'create-element-to-jsx-preserve-comments'
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-preserve-comments'
+  );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-ignore-bad-capitalization'
   );
 
   it('throws when it does not recognize a property type', () => {

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -130,6 +130,10 @@ module.exports = function(file, api, options) {
     return identifier;
   };
 
+  const isCapitalizationInvalid = (node) =>
+    (node.type === 'Literal' && !/^[a-z]/.test(node.value)) ||
+    (node.type === 'Identifier' && /^[a-z]/.test(node.name));
+
   const convertNodeToJSX = (node) => {
     const comments = node.value.comments;
     const {callee} = node.value;
@@ -142,6 +146,10 @@ module.exports = function(file, api, options) {
     }
 
     const args = node.value.arguments;
+
+    if (isCapitalizationInvalid(args[0])) {
+      return node.value;
+    }
 
     const jsxIdentifier = jsxIdentifierFor(args[0]);
     const props = args[1];


### PR DESCRIPTION
JSX uses capitalization to determine what type of `React.createElement` call to
produce: if the name starts with a lower-case letter, `React.createElement` is
called with the name as a string. Otherwise, it is called with the name as an
identifier. This means that an expression like `React.createElement(componentClass)`
cannot be converted to JSX, since `<componentClass />` would transform to the
string form. This commit changes the script to detect and skip these cases so
that the script does not introduce correctness issues.