### PR TITLE
Fix crash in create-element-to-jsx when using spread args

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-arg-spread.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-arg-spread.input.js
@@ -1,0 +1,4 @@
+var React = require('React');
+
+React.createElement(Foo, null, ...children);
+React.createElement(Foo, null, firstChild, ...otherChildren);

--- a/transforms/__testfixtures__/create-element-to-jsx-arg-spread.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-arg-spread.output.js
@@ -1,0 +1,4 @@
+var React = require('React');
+
+<Foo>{children}</Foo>;
+<Foo>{firstChild}{otherChildren}</Foo>;

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -144,6 +144,12 @@ describe('create-element-to-jsx', () => {
     null,
     'create-element-to-jsx-ignore-bad-capitalization'
   );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-arg-spread'
+  );
 
   it('throws when it does not recognize a property type', () => {
     const jscodeshift = require('jscodeshift');

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -175,6 +175,8 @@ module.exports = function(file, api, options) {
         } else {
           return jsxChild;
         }
+      } else if (child.type === 'SpreadElement') {
+        return j.jsxExpressionContainer(child.argument);
       } else {
         return j.jsxExpressionContainer(child);
       }


### PR DESCRIPTION
The default case for child nodes is to wrap them in `JSXExpressionContainer`
nodes, but that doesn't work when a spread arg is given as a child. Spread args
in `React.createElement` are actually unnecessary (and probably bad practice)
because React can handle an array given as a child. So to fix, I just got the
underlying value from the spread (generally an array) and use that as the child.

Note that this could potentially introduce key warnings because React now sees
an actual array, but those warnings are probably good.