### PR TITLE
Fix crash due to skipped children in create-element-to-jsx

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.input.js
@@ -7,3 +7,4 @@ React.createElement('foo');
 React.createElement(_foo);
 React.createElement('_foo');
 React.createElement(foo.bar);
+React.createElement(Foo, null, React.createElement(foo));

--- a/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.output.js
@@ -7,3 +7,4 @@ React.createElement('Foo');
 <_foo />;
 React.createElement('_foo');
 <foo.bar />;
+<Foo>{React.createElement(foo)}</Foo>;

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -170,7 +170,7 @@ module.exports = function(file, api, options) {
         child.callee.object.name === 'React' &&
         child.callee.property.name === 'createElement') {
         const jsxChild = convertNodeToJSX(node.get('arguments', index + 2));
-        if ((jsxChild.comments || []).length > 0) {
+        if (jsxChild.type !== 'JSXElement' || (jsxChild.comments || []).length > 0) {
           return j.jsxExpressionContainer(jsxChild);
         } else {
           return jsxChild;


### PR DESCRIPTION
In #79, I made it so the transformation is skipped in some cases, in particular
when the capitalization is invalid. This broke an assumption elsewhere in the
code that `convertNodeToJSX` always returns a `JSXElement`, so there was a crash
if a skipped element was used as a child. To fix, we can just wrap in a
`JSXExpressionContainer` for that case.