### PR TITLE
Fix incorrect prop value strings in create-element-to-jsx

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-escaped-string.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-escaped-string.input.js
@@ -1,0 +1,7 @@
+var React = require('React');
+
+React.createElement(Foo, {bar: 'abc'});
+React.createElement(Foo, {bar: 'a\nbc'});
+React.createElement(Foo, {bar: 'ab\tc'});
+React.createElement(Foo, {bar: 'ab"c'});
+React.createElement(Foo, {bar: "ab'c"});

--- a/transforms/__testfixtures__/create-element-to-jsx-escaped-string.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-escaped-string.output.js
@@ -1,0 +1,7 @@
+var React = require('React');
+
+<Foo bar="abc" />;
+<Foo bar={'a\nbc'} />;
+<Foo bar={'ab\tc'} />;
+<Foo bar={'ab"c'} />;
+<Foo bar="ab'c" />;

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -130,6 +130,12 @@ describe('create-element-to-jsx', () => {
     __dirname,
     'create-element-to-jsx',
     null,
+    'create-element-to-jsx-escaped-string'
+  );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
     'create-element-to-jsx-no-props-arg'
   );
   defineTest(

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -19,6 +19,10 @@ module.exports = function(file, api, options) {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
 
+  const canLiteralBePropString = node =>
+    node.raw.indexOf('\\') === -1 &&
+    node.value.indexOf('"') === -1;
+
   const convertExpressionToJSXAttributes = (expression) => {
     if (!expression) {
       return {
@@ -75,7 +79,9 @@ module.exports = function(file, api, options) {
           const propertyValueType = property.value.type;
 
           let value;
-          if (propertyValueType === 'Literal' && typeof property.value.value === 'string') {
+          if (propertyValueType === 'Literal' &&
+              typeof property.value.value === 'string' &&
+              canLiteralBePropString(property.value)) {
             value = j.literal(property.value.value);
             value.comments = property.value.comments;
           } else {


### PR DESCRIPTION
JSX prop value strings are treated more like HTML strings than JavaScript
strings, so things like escape sequences don't work: it just uses a literal
backslash character. Also, if the string contains a `"` character, recast will
generate a double-quoted string with the `"` characters escaped, which isn't
valid for JSX prop strings. To fix, we wrap the string in curly braces if it
directly uses an escape sequence (i.e. the underlying code has a backslash) or
if it has a `"` character.