### PR TITLE
pure-component: support Type Annotations & Class Properties

### DIFF
--- a/transforms/__testfixtures__/pure-component.input.js
+++ b/transforms/__testfixtures__/pure-component.input.js
@@ -61,4 +61,20 @@ class ImpureClassPropertyWithTypes extends React.Component {
   }
 }
 
+class PureWithPropTypes extends React.Component {
+  static propTypes = { foo: React.PropTypes.string };
+  static foo = 'bar';
+  render() {
+    return <div />;
+  }
+}
+
+class PureWithPropTypes2 extends React.Component {
+  props: { foo: string };
+  static propTypes = { foo: React.PropTypes.string };
+  render() {
+    return <div />;
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component.input.js
+++ b/transforms/__testfixtures__/pure-component.input.js
@@ -31,4 +31,34 @@ class ImpureWithRef extends React.Component {
   }
 }
 
+class PureWithTypes extends React.Component {
+  props: { foo: string };
+  render() {
+    return <div className={this.props.foo} />;
+  }
+}
+
+type Props = { foo: string };
+
+class PureWithTypes2 extends React.Component {
+  props: Props;
+  render() {
+    return <div className={this.props.foo} />;
+  }
+}
+
+class ImpureClassProperty extends React.Component {
+  state = { foo: 2 };
+  render() {
+    return <div />;
+  }
+}
+
+class ImpureClassPropertyWithTypes extends React.Component {
+  state: { x: string };
+  render() {
+    return <div />;
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component.output.js
+++ b/transforms/__testfixtures__/pure-component.output.js
@@ -29,4 +29,28 @@ class ImpureWithRef extends React.Component {
   }
 }
 
+function PureWithTypes(props: { foo: string }) {
+  return <div className={props.foo} />;
+}
+
+type Props = { foo: string };
+
+function PureWithTypes2(props: Props) {
+  return <div className={props.foo} />;
+}
+
+class ImpureClassProperty extends React.Component {
+  state = { foo: 2 };
+  render() {
+    return <div />;
+  }
+}
+
+class ImpureClassPropertyWithTypes extends React.Component {
+  state: { x: string };
+  render() {
+    return <div />;
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component.output.js
+++ b/transforms/__testfixtures__/pure-component.output.js
@@ -53,4 +53,17 @@ class ImpureClassPropertyWithTypes extends React.Component {
   }
 }
 
+function PureWithPropTypes(props) {
+  return <div />;
+}
+
+PureWithPropTypes.propTypes = { foo: React.PropTypes.string };
+PureWithPropTypes.foo = 'bar';
+
+function PureWithPropTypes2(props: { foo: string }) {
+  return <div />;
+}
+
+PureWithPropTypes2.propTypes = { foo: React.PropTypes.string };
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component2.input.js
+++ b/transforms/__testfixtures__/pure-component2.input.js
@@ -21,4 +21,20 @@ class Impure extends React.Component {
   }
 }
 
+class PureWithTypes extends React.Component {
+  props: { foo: string };
+  render() {
+    return <div className={this.props.foo} />;
+  }
+}
+
+type Props = { foo: string };
+
+class PureWithTypes2 extends React.Component {
+  props: Props;
+  render() {
+    return <div className={this.props.foo} />;
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component2.input.js
+++ b/transforms/__testfixtures__/pure-component2.input.js
@@ -37,4 +37,11 @@ class PureWithTypes2 extends React.Component {
   }
 }
 
+class PureWithPropTypes extends React.Component {
+  static propTypes = { foo: React.PropTypes.string };
+  render() {
+    return <div />;
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component2.output.js
+++ b/transforms/__testfixtures__/pure-component2.output.js
@@ -29,4 +29,10 @@ const PureWithTypes2 = (props: Props) => {
   return <div className={props.foo} />;
 };
 
+const PureWithPropTypes = props => {
+  return <div />;
+};
+
+PureWithPropTypes.propTypes = { foo: React.PropTypes.string };
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component2.output.js
+++ b/transforms/__testfixtures__/pure-component2.output.js
@@ -19,4 +19,14 @@ class Impure extends React.Component {
   }
 }
 
+const PureWithTypes = (props: { foo: string }) => {
+  return <div className={props.foo} />;
+};
+
+type Props = { foo: string };
+
+const PureWithTypes2 = (props: Props) => {
+  return <div className={props.foo} />;
+};
+
 var A = props => <div className={props.foo} />;


### PR DESCRIPTION
I was going to split this into a few PRs, but they're kinda related.

Firstly, it now treats any Component with a `ClassProperty` which isn't `props` as being impure.

Secondly, it retains any static `ClassProperty`s.

Finally, it retains `props` type annotations when transforming to a function.

I haven't used jscodeshift before, so happy to make any changes if there's a cleaner way of accomplishing it :)

``` js
// input
class PureWithTypes extends React.Component {
  props: { foo: string };
  render() {
    return <div className={this.props.foo} />;
  }
}

// output
const PureWithTypes = (props: { foo: string }) => {
  return <div className={props.foo} />;
}
```
