### PR TITLE
Skip computed component values in create-element-to-jsx

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-computed-component.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-computed-component.input.js
@@ -1,0 +1,5 @@
+var React = require('React');
+
+React.createElement(a[b]);
+React.createElement(a[b.c]);
+React.createElement(f());

--- a/transforms/__testfixtures__/create-element-to-jsx-computed-component.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-computed-component.output.js
@@ -1,0 +1,5 @@
+var React = require('React');
+
+React.createElement(a[b]);
+React.createElement(a[b.c]);
+React.createElement(f());

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -156,6 +156,12 @@ describe('create-element-to-jsx', () => {
     null,
     'create-element-to-jsx-arg-spread'
   );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-computed-component'
+  );
 
   it('throws when it does not recognize a property type', () => {
     const jscodeshift = require('jscodeshift');

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -120,6 +120,12 @@ module.exports = function(file, api, options) {
     }
   };
 
+  const canConvertToJSXIdentifier = node =>
+    (node.type === 'Literal' && typeof node.value === 'string') ||
+    node.type === 'Identifier' ||
+    (node.type === 'MemberExpression' && !node.computed &&
+      canConvertToJSXIdentifier(node.object) && canConvertToJSXIdentifier(node.property));
+
   const jsxIdentifierFor = node => {
     let identifier;
     if (node.type === 'Literal') {
@@ -153,7 +159,7 @@ module.exports = function(file, api, options) {
 
     const args = node.value.arguments;
 
-    if (isCapitalizationInvalid(args[0])) {
+    if (isCapitalizationInvalid(args[0]) || !canConvertToJSXIdentifier(args[0])) {
       return node.value;
     }
 


### PR DESCRIPTION
The create-element-to-jsx script was almost always calling `jsxIdentifierFor`,
which assumed that the expression consisted of strings, identifiers, and
non-computed member expressions (i.e. dot syntax rather than brackets syntax).
This ended up crashing or causing incorrect output when run on more dynamic code
like `React.createElement(a[b])`, `React.createElement(a[b.c])`, and
`React.createElement(f())`.