### PR TITLE
Format JSX children across multiple lines in create-element-to-jsx

### DIFF
--- a/transforms/__testfixtures__/create-element-to-jsx-allow-member-expression.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-allow-member-expression.output.js
@@ -1,3 +1,5 @@
 var React = require('react/addons');
 
-<React.addons.CSSTransitionGroup></React.addons.CSSTransitionGroup>;
+<React.addons.CSSTransitionGroup>
+  {''}
+</React.addons.CSSTransitionGroup>;

--- a/transforms/__testfixtures__/create-element-to-jsx-arg-spread.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-arg-spread.output.js
@@ -1,4 +1,9 @@
 var React = require('React');
 
-<Foo>{children}</Foo>;
-<Foo>{firstChild}{otherChildren}</Foo>;
+<Foo>
+  {children}
+</Foo>;
+<Foo>
+  {firstChild}
+  {otherChildren}
+</Foo>;

--- a/transforms/__testfixtures__/create-element-to-jsx-call-as-children.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-call-as-children.output.js
@@ -1,3 +1,5 @@
 var React = require('react/addons');
 
-<div>{foo()}</div>;
+<div>
+  {foo()}
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-call-expression-as-prop.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-call-expression-as-prop.output.js
@@ -1,3 +1,5 @@
 var React = require('react/addons');
 
-<div {...getProps()}>foo</div>;
+<div {...getProps()}>
+  foo
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-children-literal.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-children-literal.output.js
@@ -1,3 +1,5 @@
 var React = require('React');
 
-<div>foo</div>;
+<div>
+  foo
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-children-map.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-children-map.output.js
@@ -1,3 +1,5 @@
 var React = require('React');
 
-<div>{foo.map(function() {})}</div>;
+<div>
+  {foo.map(function() {})}
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-children-mixed-empty-string.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-children-mixed-empty-string.output.js
@@ -2,4 +2,8 @@ var React = require('react');
 
 a = 'foo';
 
-<div>{a} {a}</div>;
+<div>
+  {a}
+  {' '}
+  {a}
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-children.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-children.output.js
@@ -1,3 +1,8 @@
 var React = require('React');
 
-var a = <Foo><div foo="bar" /><span>blah</span></Foo>;
+var a = <Foo>
+  <div foo="bar" />
+  <span>
+    blah
+  </span>
+</Foo>;

--- a/transforms/__testfixtures__/create-element-to-jsx-deep-nesting.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-deep-nesting.input.js
@@ -1,0 +1,21 @@
+var React = require('react/addons');
+
+React.createElement(
+  'div',
+  {},
+  React.createElement(
+    'span',
+    {},
+    React.createElement(
+      'button',
+      {},
+      React.createElement(
+        'a',
+        {href: 'https://www.google.com'},
+        React.createElement('audio')
+      )
+    ),
+    React.createElement('br'),
+    React.createElement('img')
+  )
+);

--- a/transforms/__testfixtures__/create-element-to-jsx-deep-nesting.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-deep-nesting.output.js
@@ -1,0 +1,13 @@
+var React = require('react/addons');
+
+<div>
+  <span>
+    <button>
+      <a href="https://www.google.com">
+        <audio />
+      </a>
+    </button>
+    <br />
+    <img />
+  </span>
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-gt-lt-entities.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-gt-lt-entities.output.js
@@ -1,3 +1,5 @@
 var React = require('React');
 
-<div>&lt;&gt;</div>;
+<div>
+  &lt;&gt;
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-ignore-bad-capitalization.output.js
@@ -7,4 +7,6 @@ React.createElement('Foo');
 <_foo />;
 React.createElement('_foo');
 <foo.bar />;
-<Foo>{React.createElement(foo)}</Foo>;
+<Foo>
+  {React.createElement(foo)}
+</Foo>;

--- a/transforms/__testfixtures__/create-element-to-jsx-literal-spacing.input.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-literal-spacing.input.js
@@ -1,0 +1,15 @@
+var React = require('react/addons');
+
+const recipient = 'world';
+React.createElement(
+  'span',
+  {},
+  'Hello ',
+  recipient
+);
+React.createElement(
+  'span',
+  {},
+  'Water',
+  recipient
+);

--- a/transforms/__testfixtures__/create-element-to-jsx-literal-spacing.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-literal-spacing.output.js
@@ -1,0 +1,11 @@
+var React = require('react/addons');
+
+const recipient = 'world';
+<span>
+  {'Hello '}
+  {recipient}
+</span>;
+<span>
+  Water
+  {recipient}
+</span>;

--- a/transforms/__testfixtures__/create-element-to-jsx-member-expression-as-prop.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-member-expression-as-prop.output.js
@@ -1,3 +1,5 @@
 var React = require('react/addons');
 
-<div {...this.props}>foo</div>;
+<div {...this.props}>
+  foo
+</div>;

--- a/transforms/__testfixtures__/create-element-to-jsx-preserve-comments.output.js
+++ b/transforms/__testfixtures__/create-element-to-jsx-preserve-comments.output.js
@@ -5,20 +5,28 @@ const render = () => {
     /*8*/className/*9*/=/*10*/"foo"/*11*/
     /*12*/
     /*13*///17
-    onClick/*14*/={/*15*/ this.handleClick}/*16*/>{/*19*///25
-    </*20*/TodoList/*21*/./*22*/Item/*23*/ />/*24*/}<span {.../*26*/getProps()/*27*/} /><input /*28*//*29*/ /></div>;
+    onClick/*14*/={/*15*/ this.handleClick}/*16*/>
+    {/*19*///25
+    </*20*/TodoList/*21*/./*22*/Item/*23*/ />/*24*/}
+    <span {.../*26*/getProps()/*27*/} />
+    <input /*28*//*29*/ />
+  </div>;
 };
 
 const render2 = () => {
   return <div
     // Prop comment.
-    className="foo">{// Child string comment.
-    'hello'}</div>;
+    className="foo">
+    {// Child string comment.
+    'hello'}
+  </div>;
 };
 
 const render3 = () => {
-  return <div>{// Child element comment.
-    <span />}</div>;
+  return <div>
+    {// Child element comment.
+    <span />}
+  </div>;
 };
 
 const render4 = () => {

--- a/transforms/__tests__/create-element-to-jsx-test.js
+++ b/transforms/__tests__/create-element-to-jsx-test.js
@@ -162,6 +162,18 @@ describe('create-element-to-jsx', () => {
     null,
     'create-element-to-jsx-computed-component'
   );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-deep-nesting'
+  );
+  defineTest(
+    __dirname,
+    'create-element-to-jsx',
+    null,
+    'create-element-to-jsx-literal-spacing'
+  );
 
   it('throws when it does not recognize a property type', () => {
     const jscodeshift = require('jscodeshift');

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -175,7 +175,11 @@ module.exports = function(file, api, options) {
     }
 
     const children = args.slice(2).map((child, index) => {
-      if (child.type === 'Literal' && typeof child.value === 'string' && !child.comments) {
+      if (child.type === 'Literal' &&
+          typeof child.value === 'string' &&
+          !child.comments &&
+          child.value !== '' &&
+          child.value.trim() === child.value) {
         return j.jsxText(encodeJSXTextValue(child.value));
       } else if (child.type === 'CallExpression' &&
         child.callee.object &&
@@ -198,10 +202,16 @@ module.exports = function(file, api, options) {
 
     if (children.length) {
       const endIdentifier = Object.assign({}, jsxIdentifier, {comments: []});
+      // Add text newline nodes between elements so recast formats one child per
+      // line instead of all children on one line.
+      const paddedChildren = [j.jsxText('\n')];
+      for (const child of children) {
+        paddedChildren.push(child, j.jsxText('\n'));
+      }
       const element = j.jsxElement(
         openingElement,
         j.jsxClosingElement(endIdentifier),
-        children
+        paddedChildren
       );
       element.comments = comments;
       return element;


### PR DESCRIPTION
See https://github.com/benjamn/recast/issues/365 for more context.

It looks like the recast printer includes all JSX on the same line by default,
which can lead to really ugly code with deeply nested React elements. However,
if we put a `'\n'` text node around all adjacent children, it will format the
JSX in the typical multiline way, properly indented, so this commit changes the
script to do that.

Ideally, we might want to keep some expressions inline, e.g. by determining
whether the child expressions will fit nicely on one line, but that seems sort
of nontrivial with just the AST, so we just use multiline JSX always for now.

To keep strings correct, we need to be a little more careful about translating
child string literals. Since each child will be on its own line, leading and
trailing whitespace will be removed, so if the string literal starts or ends
with whitespace, or is an empty string, we fall back to an expression container
with a normal JS string.