### PR TITLE
Migrate ReactNative View.propTypes to ViewPropTypes

### DIFF
--- a/transforms/ReactNative-View-propTypes.js
+++ b/transforms/ReactNative-View-propTypes.js
@@ -20,7 +20,10 @@ const isReactNativeRequire = path => (
 
 const isRootViewReference = path => (
   path.node.name === 'View' &&
-  path.parent.node.type !== 'MemberExpression' &&
+  (
+    path.parent.node.type !== 'MemberExpression' ||
+    path.parent.node.object === path.node
+  ) &&
   (
     path.node.type !== 'JSXIdentifier' ||
     path.parent.node.type === 'JSXOpeningElement'
@@ -140,7 +143,8 @@ module.exports = function(file, api, options) {
 
     // If the only View reference left is the import/require(), replace it
     // Else insert our new import/require() after it
-    const replaceExistingImportOrRequireStatement = viewReferenceCount <= numMatchedPaths;
+    // Add one to avoid counting the import/require() statement itself
+    const replaceExistingImportOrRequireStatement = viewReferenceCount <= numMatchedPaths + 1;
 
     if (fileUsesImports) {
       root

--- a/transforms/ReactNative-View-propTypes.js
+++ b/transforms/ReactNative-View-propTypes.js
@@ -95,8 +95,8 @@ module.exports = function(file, api, options) {
   // Add ViewPropTypes import/require()
   if (numMatchedPaths > 0) {
     const fileUsesImports = root
-      .find(j.ImportDeclaration)
-      .length > 0;
+      .find(j.CallExpression, {callee: {name: 'require'}})
+      .length === 0;
 
     // Determine which kind of import/require() we should create based on file contents
     let useHasteModules = false

--- a/transforms/ReactNative-View-propTypes.js
+++ b/transforms/ReactNative-View-propTypes.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const isRootJSXViewReference = path => (
+  path.node.name === 'View' &&
+  path.parent.node.type === 'JSXOpeningElement'
+);
+
+const isRootViewReference = path => (
+  path.node.name === 'View' &&
+  path.parent.node.type !== 'MemberExpression' &&
+  path.node.type !== 'JSXIdentifier' &&
+  (
+    path.parent.node.type !== 'ImportSpecifier' ||
+    path.parent.node.imported === path.node
+  ) &&
+  (
+    path.parent.node.type !== 'Property' ||
+    path.parent.node.key === path.node
+  )
+);
+
+const isViewImport = path => (
+  path.node.specifiers.some(specifier => (
+    specifier.imported &&
+    specifier.imported.name === 'View' ||
+    specifier.local &&
+    specifier.local.name === 'View'
+  ))
+);
+
+const isViewRequire = path => (
+  path.node.callee.type === 'Identifier' &&
+  path.parent.node.type === 'VariableDeclarator' &&
+  (
+    path.parent.node.id.type === 'Identifier' &&
+    path.parent.node.id.name === 'View' ||
+    path.parent.node.id.type === 'ObjectPattern' &&
+    path.parent.node.id.properties.some(
+      property => property.value.name === 'View'
+    )
+  )
+);
+
+const isViewPropTypes = path => (
+  path.node.name === 'propTypes' &&
+  path.parent.node.type === 'MemberExpression' &&
+  path.parent.value.object.name === 'View'
+);
+
+module.exports = function(file, api, options) {
+  const j = api.jscodeshift;
+
+  let root = j(file.source);
+
+  let numMatchedPaths = 0;
+
+  // Search for remaining view references
+  const viewReferenceCount = root
+    .find(j.Identifier)
+    .filter(isRootViewReference)
+    .length;
+  const jsxViewReferenceCount = root
+    .find(j.JSXIdentifier)
+    .filter(isRootJSXViewReference)
+    .length;
+
+  // Replace View.propTypes with ViewPropTypes
+  root
+    .find(j.Identifier)
+    .filter(isViewPropTypes)
+    .forEach(path => {
+      numMatchedPaths++;
+
+      j(path.parent).replaceWith(
+        j.identifier('ViewPropTypes')
+      );
+    });
+
+  // Add ViewPropTypes import
+  if (numMatchedPaths > 0) {
+    const fileUsesImports = root
+      .find(j.ImportDeclaration)
+      .length > 0;
+
+    // Add a require statement or an import, based on file convention
+    let importOrRequireStatement;
+    if (fileUsesImports) {
+      const identifier = j.identifier('ViewPropTypes');
+      const variable = j.importDefaultSpecifier(identifier);
+
+      importOrRequireStatement = j.importDeclaration(
+        [variable], j.literal('ViewPropTypes')
+      );
+    } else {
+      importOrRequireStatement = j.template.statement`
+        const ViewPropTypes = require('ViewPropTypes');
+      `;
+    }
+
+    // If the only View reference left is the import/require(), replace it
+    // Else insert our new import/require() after it
+    const replaceExistingImportOrRequireStatement = viewReferenceCount + jsxViewReferenceCount <= numMatchedPaths;
+
+    if (fileUsesImports) {
+      root
+        .find(j.ImportDeclaration)
+        .filter(isViewImport)
+        .forEach(path => {
+          if (path.node.specifiers.length > 1) {
+            // Destructured import ...
+
+            // Insert after before removing to avoid an error
+            j(path).insertAfter(importOrRequireStatement);
+
+            if (replaceExistingImportOrRequireStatement) {
+              // If this is the last reference to a destructured import, remove it
+              // We can't replace in this case b'c the destination is different
+              path.node.specifiers = path.node.specifiers.filter(
+                specifier => specifier.local.name !== 'View'
+              );
+            }
+          } else {
+            // Default import ...
+
+            if (replaceExistingImportOrRequireStatement) {
+              j(path).replaceWith(importOrRequireStatement);
+            } else {
+              j(path).insertAfter(importOrRequireStatement);
+            }
+          }
+        });
+    } else {
+      root
+        .find(j.CallExpression, {callee: {name: 'require'}})
+        .filter(isViewRequire)
+        .forEach(path => {
+          if (path.parent.node.id.type === 'ObjectPattern') {
+            // Destructured require() ...
+
+            // Insert after before removing to avoid an error
+            j(path.parent.parent).insertAfter(importOrRequireStatement);
+
+            if (replaceExistingImportOrRequireStatement) {
+              // If this is the last reference to a destructured import, remove it
+              // We can't replace in this case b'c the destination is different
+              const variableDeclarator = path.parent.parent.value.declarations[0];
+              variableDeclarator.id.properties = variableDeclarator.id.properties.filter(
+                property => property.value.name !== 'View'
+              );
+            }
+          } else {
+            // Default require ...
+
+            if (replaceExistingImportOrRequireStatement) {
+              j(path.parent.parent).replaceWith(importOrRequireStatement);
+            } else {
+              j(path.parent.parent).insertAfter(importOrRequireStatement);
+            }
+          }
+        });
+    }
+  }
+
+  return numMatchedPaths > 0
+    ? root.toSource({ quote: 'single' })
+    : null;
+};

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-multi-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-multi-reference.input.js
@@ -1,0 +1,10 @@
+import { PropTypes } from 'react';
+import View from 'View';
+
+function Component() {
+  return <View />;
+}
+
+Component.propTypes = View.propTypes;
+
+module.exports = Component;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-multi-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-multi-reference.output.js
@@ -1,0 +1,12 @@
+import { PropTypes } from 'react';
+import View from 'View';
+
+import ViewPropTypes from 'ViewPropTypes';
+
+function Component() {
+  return <View />;
+}
+
+Component.propTypes = ViewPropTypes;
+
+module.exports = Component;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-only-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-only-reference.input.js
@@ -1,0 +1,11 @@
+import { PropTypes } from 'react';
+import Text from 'Text';
+import View from 'View';
+
+function Component() {
+  return <Text>text</Text>;
+}
+
+Component.propTypes = View.propTypes;
+
+module.exports = Component;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-only-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-import-only-reference.output.js
@@ -1,0 +1,11 @@
+import { PropTypes } from 'react';
+import Text from 'Text';
+import ViewPropTypes from 'ViewPropTypes';
+
+function Component() {
+  return <Text>text</Text>;
+}
+
+Component.propTypes = ViewPropTypes;
+
+module.exports = Component;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-multi-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-multi-reference.input.js
@@ -1,0 +1,19 @@
+var React = require('React');
+var View = require('View');
+
+var PropTypes = React.PropTypes;
+
+class ASTrackView extends React.Component {
+  static propTypes = {
+    style: View.propTypes.style,
+    track: PropTypes.object.isRequired,
+  };
+
+  render() {
+    return (
+      <View style={this.props.style}>
+        {this.props.track}
+      </View>
+    );
+  }
+}

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-multi-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-multi-reference.output.js
@@ -1,0 +1,21 @@
+var React = require('React');
+var View = require('View');
+
+const ViewPropTypes = require('ViewPropTypes');
+
+var PropTypes = React.PropTypes;
+
+class ASTrackView extends React.Component {
+  static propTypes = {
+    style: ViewPropTypes.style,
+    track: PropTypes.object.isRequired,
+  };
+
+  render() {
+    return (
+      <View style={this.props.style}>
+        {this.props.track}
+      </View>
+    );
+  }
+}

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-only-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-only-reference.input.js
@@ -1,0 +1,13 @@
+const Animated = require('Animated');
+const React = require('React');
+const View = require('View');
+
+function MyComponent() {
+  return React.createElement(Animated.View);
+}
+
+MyComponent.propTypes = {
+  style: View.propTypes.style
+};
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-only-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/default-require-only-reference.output.js
@@ -1,0 +1,13 @@
+const Animated = require('Animated');
+const React = require('React');
+const ViewPropTypes = require('ViewPropTypes');
+
+function MyComponent() {
+  return React.createElement(Animated.View);
+}
+
+MyComponent.propTypes = {
+  style: ViewPropTypes.style
+};
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-multi-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-multi-reference.input.js
@@ -1,0 +1,12 @@
+import { PropTypes } from 'react';
+import { requireNativeComponent, View } from 'react-native';
+
+const Foo = requireNativeComponent('Foo');
+
+function MyComponent(props) {
+  return <View {...props}><Foo /></View>;
+}
+
+MyComponent.propTypes = View.propTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-multi-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-multi-reference.output.js
@@ -1,7 +1,5 @@
 import { PropTypes } from 'react';
-import { requireNativeComponent, View } from 'react-native';
-
-import ViewPropTypes from 'ViewPropTypes';
+import { requireNativeComponent, View, ViewPropTypes } from 'react-native';
 
 const Foo = requireNativeComponent('Foo');
 

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-multi-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-multi-reference.output.js
@@ -1,0 +1,14 @@
+import { PropTypes } from 'react';
+import { requireNativeComponent, View } from 'react-native';
+
+import ViewPropTypes from 'ViewPropTypes';
+
+const Foo = requireNativeComponent('Foo');
+
+function MyComponent(props) {
+  return <View {...props}><Foo /></View>;
+}
+
+MyComponent.propTypes = ViewPropTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-only-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-only-reference.input.js
@@ -1,0 +1,12 @@
+import { PropTypes } from 'react';
+import { requireNativeComponent, View } from 'react-native';
+
+const Foo = requireNativeComponent('Foo');
+
+function MyComponent(props) {
+  return <Foo {...props} />;
+}
+
+MyComponent.propTypes = View.propTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-only-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-only-reference.output.js
@@ -1,7 +1,5 @@
 import { PropTypes } from 'react';
-import { requireNativeComponent } from 'react-native';
-
-import ViewPropTypes from 'ViewPropTypes';
+import { requireNativeComponent, ViewPropTypes } from 'react-native';
 
 const Foo = requireNativeComponent('Foo');
 

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-only-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-import-only-reference.output.js
@@ -1,0 +1,14 @@
+import { PropTypes } from 'react';
+import { requireNativeComponent } from 'react-native';
+
+import ViewPropTypes from 'ViewPropTypes';
+
+const Foo = requireNativeComponent('Foo');
+
+function MyComponent(props) {
+  return <Foo {...props} />;
+}
+
+MyComponent.propTypes = ViewPropTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-multi-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-multi-reference.input.js
@@ -1,0 +1,12 @@
+const { PropTypes } = require('react');
+const { requireNativeComponent, View } = require('react-native');
+
+const Foo = requireNativeComponent('Foo');
+
+function MyComponent(props) {
+  return <View {...props}><Foo /></View>;
+}
+
+MyComponent.propTypes = View.propTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-multi-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-multi-reference.output.js
@@ -1,7 +1,9 @@
 const { PropTypes } = require('react');
-const { requireNativeComponent, View } = require('react-native');
-
-const ViewPropTypes = require('ViewPropTypes');
+const {
+  requireNativeComponent,
+  View,
+  ViewPropTypes
+} = require('react-native');
 
 const Foo = requireNativeComponent('Foo');
 

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-multi-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-multi-reference.output.js
@@ -1,0 +1,14 @@
+const { PropTypes } = require('react');
+const { requireNativeComponent, View } = require('react-native');
+
+const ViewPropTypes = require('ViewPropTypes');
+
+const Foo = requireNativeComponent('Foo');
+
+function MyComponent(props) {
+  return <View {...props}><Foo /></View>;
+}
+
+MyComponent.propTypes = ViewPropTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-only-reference.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-only-reference.input.js
@@ -1,0 +1,10 @@
+const PropTypes = require('react');
+const { Animated, View } = require('react-native');
+
+function MyComponent(props) {
+  return <Animated.View {...props} />;
+}
+
+MyComponent.propTypes = View.propTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-only-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-only-reference.output.js
@@ -1,0 +1,14 @@
+const PropTypes = require('react');
+const {
+  Animated
+} = require('react-native');
+
+const ViewPropTypes = require('ViewPropTypes');
+
+function MyComponent(props) {
+  return <Animated.View {...props} />;
+}
+
+MyComponent.propTypes = ViewPropTypes;
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-only-reference.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/destructured-require-only-reference.output.js
@@ -1,9 +1,5 @@
 const PropTypes = require('react');
-const {
-  Animated
-} = require('react-native');
-
-const ViewPropTypes = require('ViewPropTypes');
+const { Animated, ViewPropTypes } = require('react-native');
 
 function MyComponent(props) {
   return <Animated.View {...props} />;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/import-flow-type-with-require.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/import-flow-type-with-require.input.js
@@ -1,0 +1,15 @@
+const Animated = require('Animated');
+const React = require('React');
+const View = require('View');
+
+import type { Foo } from 'Foo';
+
+function MyComponent(): Foo {
+  return React.createElement(Animated.View);
+}
+
+MyComponent.propTypes = {
+  style: View.propTypes.style
+};
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/import-flow-type-with-require.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/import-flow-type-with-require.output.js
@@ -1,0 +1,15 @@
+const Animated = require('Animated');
+const React = require('React');
+const ViewPropTypes = require('ViewPropTypes');
+
+import type { Foo } from 'Foo';
+
+function MyComponent(): Foo {
+  return React.createElement(Animated.View);
+}
+
+MyComponent.propTypes = {
+  style: ViewPropTypes.style
+};
+
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/multiple-replacements.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/multiple-replacements.input.js
@@ -1,0 +1,29 @@
+const React = require('React');
+const ScrollView = require('ScrollView');
+const View = require('View');
+
+const PropTypes = React.PropTypes;
+
+class AdsManagerAbstractRow extends React.Component {
+  static propTypes = {
+    containerStyle: View.propTypes.style,
+    style: View.propTypes.style,
+  };
+
+  render() {
+    let child = null;
+    if (this.props.child) {
+      child = (
+        <View style={this.props.childContainerStyle}>
+          {this.props.child}
+        </View>
+      );
+    }
+
+    return (
+      <ScrollView style={this.props.style}>
+        {child}
+      </ScrollView>
+    );
+  }
+}

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/multiple-replacements.output.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/multiple-replacements.output.js
@@ -1,0 +1,31 @@
+const React = require('React');
+const ScrollView = require('ScrollView');
+const View = require('View');
+
+const ViewPropTypes = require('ViewPropTypes');
+
+const PropTypes = React.PropTypes;
+
+class AdsManagerAbstractRow extends React.Component {
+  static propTypes = {
+    containerStyle: ViewPropTypes.style,
+    style: ViewPropTypes.style,
+  };
+
+  render() {
+    let child = null;
+    if (this.props.child) {
+      child = (
+        <View style={this.props.childContainerStyle}>
+          {this.props.child}
+        </View>
+      );
+    }
+
+    return (
+      <ScrollView style={this.props.style}>
+        {child}
+      </ScrollView>
+    );
+  }
+}

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/noop-import.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/noop-import.input.js
@@ -1,0 +1,6 @@
+import React from 'React';
+import View from 'View';
+
+module.exports = function Component() {
+  return <View />;
+};

--- a/transforms/__testfixtures__/ReactNative-View-propTypes/noop-require.input.js
+++ b/transforms/__testfixtures__/ReactNative-View-propTypes/noop-require.input.js
@@ -1,0 +1,6 @@
+const React = require('React');
+const View = require('View');
+
+module.exports = function Component() {
+  return <View />;
+};

--- a/transforms/__tests__/ReactNative-View-propTypes-test.js
+++ b/transforms/__tests__/ReactNative-View-propTypes-test.js
@@ -20,6 +20,7 @@ const tests = [
   'destructured-require-multi-reference',
   'destructured-require-only-reference',
   'import-flow-type-with-require',
+  'multiple-replacements',
   'noop-import',
   'noop-require',
 ];

--- a/transforms/__tests__/ReactNative-View-propTypes-test.js
+++ b/transforms/__tests__/ReactNative-View-propTypes-test.js
@@ -19,6 +19,7 @@ const tests = [
   'destructured-import-only-reference',
   'destructured-require-multi-reference',
   'destructured-require-only-reference',
+  'import-flow-type-with-require',
   'noop-import',
   'noop-require',
 ];

--- a/transforms/__tests__/ReactNative-View-propTypes-test.js
+++ b/transforms/__tests__/ReactNative-View-propTypes-test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const tests = [
+  'default-import-multi-reference',
+  'default-import-only-reference',
+  'default-require-multi-reference',
+  'default-require-only-reference',
+  'destructured-import-multi-reference',
+  'destructured-import-only-reference',
+  'destructured-require-multi-reference',
+  'destructured-require-only-reference',
+  'noop-import',
+  'noop-require',
+];
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+describe('ReactNative-View-propTypes', () => {
+  tests.forEach(test =>
+    defineTest(
+      __dirname,
+      'ReactNative-View-propTypes',
+      null,
+      `ReactNative-View-propTypes/${ test }`
+    )
+  );
+});


### PR DESCRIPTION
`ReactNative` will soon be deprecating `View.propTypes` in favor of `ViewPropTypes`. This codemod helps with that deprecation by doing the following:
* Updates all references to `View.propTypes` and replaces them with `ViewPropTypes`.
* Adds an `import` or `require` statement (depending on the convention followed in the parent file) for the new `ViewPropTypes`.
* Removes the `import`/`require` statement for `View` if it is no longer in use.
* Uses Haste modules (eg `import ViewPropTypes from 'ViewPropTypes';`) if it detects their use in the file else uses Node modules (eg `import { ViewPropTypes } from 'react-native';`).

### Testing

In addition to the newly added Jest tests this codemod was also run internally against Facebook's `ReactNative` code.

### Caveats

This codemod may introduce an unnecessary newline before certain types of imports. This is not a problem with the codemod but with recast. See facebook/jscodeshift/issues/185 and benjamn/recast/issues/371

This codemod doesn't handle the case demonstrated below:
```jsx
const ReactNative = require('react-native');
const { View } = ReactNative;
```

This pattern isn't common within Facebook and I didn't think it would be worth the extra complexity it would add to the codemod. If others feel strongly about this I could add support for it.