### PR TITLE
Update class transform to fallback to react-create-class package

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ jscodeshift -t react-codemod/transforms/sort-comp.js <path>
   - Notice that Flow treats an optional propType as non-nullable
     - For example, `foo: React.PropTypes.number` is valid when you pass `{}`, `{foo: null}`, or `{foo: undefined}` as props at **runtime**. However, when Flow infers type from a `createClass` call, only `{}` and `{foo: undefined}` are valid; `{foo: null}` is not. Thus the equivalent type annotation in Flow is actually `{foo?: number}`. The question mark on the left hand side indicates `{}` and `{foo: undefined}` are fine, but when `foo` is present it must be a `number`
   - For `propTypes` fields that can't be recognized by Flow, `$FlowFixMe` will be used
+5. `React.createClass` is no longer present in React 16. So, if a `createClass` call cannot be converted to a plain class, the script will fallback to using the `react-create-class` package.
+  - Replaces `React.createClass` with `ReactCreateClass`.
+  - Adds a `require` or `import` statement for `react-create-class`. The import style is inferred from the import style of the `react` import. The default module name can be overridden with the `--create-class-module-name` option.
+  - Prunes the `react` import if there are no more references to it.
 
 #### Usage
 ```bash

--- a/transforms/__testfixtures__/class/class-initial-state.output.js
+++ b/transforms/__testfixtures__/class/class-initial-state.output.js
@@ -2,6 +2,8 @@
 
 import React from 'React';
 
+import ReactCreateClass from 'react-create-class';
+
 type SomeState = {foo: string};
 
 // only needs props
@@ -223,7 +225,7 @@ class DeferStateInitialization extends React.Component {
 
 var helper = () => {};
 
-var PassGetInitialState = React.createClass({ // bail out here
+var PassGetInitialState = ReactCreateClass({ // bail out here
   getInitialState() {
     return this.lol();
   },
@@ -237,7 +239,7 @@ var PassGetInitialState = React.createClass({ // bail out here
   },
 });
 
-var UseGetInitialState = React.createClass({ // bail out here
+var UseGetInitialState = ReactCreateClass({ // bail out here
   getInitialState() {
     return this.lol();
   },
@@ -251,7 +253,7 @@ var UseGetInitialState = React.createClass({ // bail out here
   },
 });
 
-var UseArguments = React.createClass({ // bail out here
+var UseArguments = ReactCreateClass({ // bail out here
   helper() {
     console.log(arguments);
   },
@@ -261,7 +263,7 @@ var UseArguments = React.createClass({ // bail out here
   },
 });
 
-var ShadowingIssue = React.createClass({ // bail out here
+var ShadowingIssue = ReactCreateClass({ // bail out here
   getInitialState() {
     const props = { x: 123 };
     return { x: props.x };

--- a/transforms/__testfixtures__/class/class-prune-react.input.js
+++ b/transforms/__testfixtures__/class/class-prune-react.input.js
@@ -1,0 +1,16 @@
+'use strict';
+
+import React from 'React';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default React.createClass({
+  mixins: [SomeMixin],
+  render: function() {
+    return null;
+  },
+});

--- a/transforms/__testfixtures__/class/class-prune-react.output.js
+++ b/transforms/__testfixtures__/class/class-prune-react.output.js
@@ -1,0 +1,16 @@
+'use strict';
+
+import ReactCreateClass from 'react-create-class';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default ReactCreateClass({
+  mixins: [SomeMixin],
+  render: function() {
+    return null;
+  },
+});

--- a/transforms/__testfixtures__/class/class-prune-react2.input.js
+++ b/transforms/__testfixtures__/class/class-prune-react2.input.js
@@ -1,0 +1,16 @@
+'use strict';
+
+import React from 'React';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default React.createClass({
+  mixins: [SomeMixin],
+  render: function() {
+    return <div />;
+  },
+});

--- a/transforms/__testfixtures__/class/class-prune-react2.output.js
+++ b/transforms/__testfixtures__/class/class-prune-react2.output.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import React from 'React';
+
+import ReactCreateClass from 'react-create-class';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default ReactCreateClass({
+  mixins: [SomeMixin],
+  render: function() {
+    return <div />;
+  },
+});

--- a/transforms/__testfixtures__/class/class-prune-react3.input.js
+++ b/transforms/__testfixtures__/class/class-prune-react3.input.js
@@ -1,0 +1,19 @@
+'use strict';
+
+import React, {PropTypes} from 'React';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default React.createClass({
+  mixins: [SomeMixin],
+  propTypes: {
+    foo: PropTypes.string,
+  },
+  render: function() {
+    return null;
+  },
+});

--- a/transforms/__testfixtures__/class/class-prune-react3.output.js
+++ b/transforms/__testfixtures__/class/class-prune-react3.output.js
@@ -1,0 +1,21 @@
+'use strict';
+
+import {PropTypes} from 'React';
+
+import ReactCreateClass from 'react-create-class';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default ReactCreateClass({
+  mixins: [SomeMixin],
+  propTypes: {
+    foo: PropTypes.string,
+  },
+  render: function() {
+    return null;
+  },
+});

--- a/transforms/__testfixtures__/class/class-pure-mixin3.input.js
+++ b/transforms/__testfixtures__/class/class-pure-mixin3.input.js
@@ -1,5 +1,5 @@
 // for this file we disable the `pure-component` option
-// so the output should be just nothing
+// so we should not convert to a plain class
 var React = require('React');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 

--- a/transforms/__testfixtures__/class/class-pure-mixin3.output.js
+++ b/transforms/__testfixtures__/class/class-pure-mixin3.output.js
@@ -1,5 +1,6 @@
 // for this file we disable the `pure-component` option
 // so we should not convert to a plain class
+var React = require('React');
 var ReactCreateClass = require('react-create-class');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 

--- a/transforms/__testfixtures__/class/class-pure-mixin3.output.js
+++ b/transforms/__testfixtures__/class/class-pure-mixin3.output.js
@@ -1,0 +1,20 @@
+// for this file we disable the `pure-component` option
+// so we should not convert to a plain class
+var ReactCreateClass = require('react-create-class');
+var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
+
+var ComponentWithOnlyPureRenderMixin = ReactCreateClass({
+  mixins: [ReactComponentWithPureRenderMixin],
+
+  getInitialState: function() {
+    return {
+      counter: this.props.initialNumber + 1,
+    };
+  },
+
+  render: function() {
+    return (
+      <div>{this.state.counter}</div>
+    );
+  },
+});

--- a/transforms/__testfixtures__/class/class-test2.output.js
+++ b/transforms/__testfixtures__/class/class-test2.output.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('React');
+var ReactCreateClass = require('react-create-class');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 var FooBarMixin = require('FooBarMixin');
 
@@ -48,7 +49,7 @@ module.exports = class extends React.Component {
   }
 };
 
-var ComponentWithInconvertibleMixins = React.createClass({
+var ComponentWithInconvertibleMixins = ReactCreateClass({
   mixins: [ReactComponentWithPureRenderMixin, FooBarMixin],
 
   getInitialState: function() {
@@ -66,7 +67,7 @@ var ComponentWithInconvertibleMixins = React.createClass({
 
 var listOfInconvertibleMixins = [ReactComponentWithPureRenderMixin, FooBarMixin];
 
-var ComponentWithInconvertibleMixins2 = React.createClass({
+var ComponentWithInconvertibleMixins2 = ReactCreateClass({
   mixins: listOfInconvertibleMixins,
 
   getInitialState: function() {

--- a/transforms/__testfixtures__/class/class.output.js
+++ b/transforms/__testfixtures__/class/class.output.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('React');
+var ReactCreateClass = require('react-create-class');
 var Relay = require('Relay');
 
 var Image = require('Image.react');
@@ -108,7 +109,7 @@ class MyComponent3 extends React.Component {
   }
 }
 
-var MyComponent4 = React.createClass({
+var MyComponent4 = ReactCreateClass({
   foo: callMeMaybe(),
   render: function() {},
 });
@@ -166,9 +167,9 @@ class SingleArgArrowFunction extends React.Component {
 }
 
 var mySpec = {};
-var NotAnObjectLiteral = React.createClass(mySpec);
+var NotAnObjectLiteral = ReactCreateClass(mySpec);
 
-var WaitWhat = React.createClass();
+var WaitWhat = ReactCreateClass();
 
 class HasSpreadArgs extends React.Component {
   _helper = (...args) => {

--- a/transforms/__tests__/class-test.js
+++ b/transforms/__tests__/class-test.js
@@ -50,3 +50,4 @@ defineTest(__dirname, 'class', {
   ...enableFlowOption,
   'remove-runtime-proptypes': true,
 }, 'class/class-flow7');
+defineTest(__dirname, 'class', null, 'class/class-prune-react');

--- a/transforms/__tests__/class-test.js
+++ b/transforms/__tests__/class-test.js
@@ -51,3 +51,4 @@ defineTest(__dirname, 'class', {
   'remove-runtime-proptypes': true,
 }, 'class/class-flow7');
 defineTest(__dirname, 'class', null, 'class/class-prune-react');
+defineTest(__dirname, 'class', null, 'class/class-prune-react2');

--- a/transforms/__tests__/class-test.js
+++ b/transforms/__tests__/class-test.js
@@ -52,3 +52,4 @@ defineTest(__dirname, 'class', {
 }, 'class/class-flow7');
 defineTest(__dirname, 'class', null, 'class/class-prune-react');
 defineTest(__dirname, 'class', null, 'class/class-prune-react2');
+defineTest(__dirname, 'class', null, 'class/class-prune-react3');

--- a/transforms/class.js
+++ b/transforms/class.js
@@ -1159,10 +1159,12 @@ module.exports = (file, api, options) => {
 
       if (reactPathAndBinding) {
         const {path, type} = reactPathAndBinding;
-        const shouldRemoveReactImport = root
+        const noReactReferences = root
           .find(j.Identifier)
           .filter(path => path.value.name === 'React')
           .length === 1;
+        const noJSX = root.find(j.JSXElement).length === 0;
+        const shouldRemoveReactImport = noReactReferences && noJSX;
         if (shouldRemoveReactImport) {
           if (type === 'require') {
             const kind = path.parent.value.kind;


### PR DESCRIPTION
If React.createClass cannot be converted to a plain JavaScript class,
it falls back to using the react-create-class package instead.