### PR TITLE
test for existance of "init" property before reading name property

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -88,6 +88,7 @@ function removeDestructuredPropTypeStatements(j, root) {
   root
     .find(j.ObjectPattern)
     .filter(path => (
+      path.parent.node.init &&
       path.parent.node.init.name === 'React' &&
       path.node.properties.some(
           property => property.key.name === 'PropTypes'


### PR DESCRIPTION
Fixes #104 

I also received the error when attempting to transform a simple file like this:

```jsx
import React from 'react';
import NextIcon from './next-icon';

function renderEditTriangle({ rowIndex }) {
    return (
        <Button id={rowIndex} plain icon={<NextIcon />} />
    );
}

renderEditTriangle.propTypes = {
    rowIndex: React.PropTypes.string
};
```

FWIW:
I added a `console.log(path.parent.node)` to see what node it was choking on:
```
Node {
  type: 'FunctionDeclaration',
  start: 64,
  end: 188,
  loc:
   SourceLocation {
     start: Position { line: 4, column: 0 },
     end: Position { line: 8, column: 1 },
     lines: Lines {},
     indent: 0 },
  id:
   Node {
     type: 'Identifier',
     start: 73,
     end: 91,
     loc: SourceLocation { start: [Object], end: [Object], lines: Lines {}, indent: 0 },
     name: 'renderEditTriangle',
     typeAnnotation: null },
  generator: false,
  expression: false,
  async: false,
  params:
   [ Node {
       type: 'ObjectPattern',
       start: 92,
       end: 104,
       loc: [Object],
       properties: [Object],
       decorators: null } ],
  body:
   Node {
     type: 'BlockStatement',
     start: 106,
     end: 188,
     loc: SourceLocation { start: [Object], end: [Object], lines: Lines {}, indent: 0 },
     body: [ [Object] ],
     directives: [] },
  defaults: [],
  rest: null,
  returnType: null,
  typeParameters: null }
```


