### PR TITLE
Fix case when you only use named import with React-PropTypes	

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -10,14 +10,6 @@
 
 'use strict';
 
-// import React from 'react';
-const isReactImport = path => (
-  path.node.specifiers.some(specifier => (
-    specifier.type === 'ImportDefaultSpecifier' &&
-    specifier.local.name === 'React'
-  ))
-);
-
 // const React = require('react');
 const isReactRequire = path => (
   path.node.callee.type === 'Identifier' &&
@@ -63,7 +55,7 @@ function addPropTypesImport(j, root) {
 
     root
       .find(j.ImportDeclaration)
-      .filter(isReactImport)
+      .filter(path => path.node.source.value.toLowerCase() === 'react')
       .forEach(path => {
         j(path).insertAfter(importStatement);
       });

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/only-named-import.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/only-named-import.input.js
@@ -1,0 +1,17 @@
+import { Component, PropTypes } from 'React';
+
+class ClassComponent extends Component {
+  static propTypes = {
+    text: PropTypes.string.isRequired,
+  };
+  render() {
+    return <div>{this.props.text}</div>;
+  }
+}
+
+function FunctionalComponent (props) {
+  return <div>{props.text}</div>;
+}
+FunctionalComponent.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/only-named-import.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/only-named-import.output.js
@@ -1,0 +1,19 @@
+import { Component } from 'React';
+
+import PropTypes from 'prop-types';
+
+class ClassComponent extends Component {
+  static propTypes = {
+    text: PropTypes.string.isRequired,
+  };
+  render() {
+    return <div>{this.props.text}</div>;
+  }
+}
+
+function FunctionalComponent (props) {
+  return <div>{props.text}</div>;
+}
+FunctionalComponent.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -15,6 +15,7 @@ const tests = [
   'default-import',
   'no-change-import',
   'no-change-require',
+  'only-named-import',
   'require-destructured-multi',
   'require-destructured-only',
   'require',


### PR DESCRIPTION
I came across this case when migrating `styled-components`. This is the first I write code for `jscodeshift`, tell me if I overlooked something.

Thanks :v: 