### PR TITLE
Fix issue with only named import of proptypes

### DIFF
--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/named-import.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/named-import.input.js
@@ -1,0 +1,5 @@
+import { PropTypes } from 'react';
+
+export default PropTypes.shape({
+  id: PropTypes.string,
+})

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/named-import.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/named-import.output.js
@@ -1,0 +1,5 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+  id: PropTypes.string,
+})

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -13,6 +13,7 @@
 const tests = [
   'default-and-named-import',
   'default-import',
+  'named-import',
   'no-change-import',
   'no-change-require',
   'require-destructured-multi',


### PR DESCRIPTION
When creating reusable shapes it one only need proptypes and might
therefore not have imported react. This change make the proptype codemod
handle this use case.

Output of the added test before the change:
```js
import 'react';

export default PropTypes.shape({
  id: PropTypes.string,
})
```

Output of the added test after the change:
```js
import PropTypes from 'prop-types';
  
export default PropTypes.shape({
  id: PropTypes.string,
})
```