### PR TITLE
Check if path.parent.node.init exists before reading its props.

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -88,6 +88,7 @@ function removeDestructuredPropTypeStatements(j, root) {
   root
     .find(j.ObjectPattern)
     .filter(path => (
+      path.parent.node.init &&
       path.parent.node.init.name === 'React' &&
       path.node.properties.some(
           property => property.key.name === 'PropTypes'


### PR DESCRIPTION
Not sure why but it was failing to read the property in some cases such as:

```js
import React, { Component, PropTypes } from 'react'
```