### PR TITLE
Ensure prop-types transform works with object pattern in arg

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -88,6 +88,7 @@ function removeDestructuredPropTypeStatements(j, root) {
   root
     .find(j.ObjectPattern)
     .filter(path => (
+      path.parent.node.type === 'VariableDeclarator' &&
       path.parent.node.init.name === 'React' &&
       path.node.properties.some(
           property => property.key.name === 'PropTypes'

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/object-pattern-in-function-args.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/object-pattern-in-function-args.input.js
@@ -1,0 +1,9 @@
+import React, { PropTypes } from 'react';
+
+function FunctionalComponent({text}) {
+  return <div>{text}</div>;
+}
+
+FunctionalComponent.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/object-pattern-in-function-args.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/object-pattern-in-function-args.output.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+function FunctionalComponent({text}) {
+  return <div>{text}</div>;
+}
+
+FunctionalComponent.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -15,6 +15,7 @@ const tests = [
   'default-import',
   'no-change-import',
   'no-change-require',
+  'object-pattern-in-function-args',
   'require-destructured-multi',
   'require-destructured-only',
   'require',


### PR DESCRIPTION
The `prop-types` transform assumes nodes of type `ObjectPattern` have a parent node with an `init` property.  This is not the case when an `ObjectPattern` is used in function params or call expression arguments (e.g. `function foo({bar}) {}` or `foo({bar})`).

It looks like this is meant to be working with a `VariableDeclarator` parent.  I've added a test that demonstrates the existing problem and updated the transform so the test passes.
