### PR TITLE
Remove trailing function comma in class transform

### DIFF
--- a/transforms/class.js
+++ b/transforms/class.js
@@ -1151,7 +1151,7 @@ module.exports = (file, api, options) => {
          ? j.callExpression(j.identifier(CREATE_CLASS_VARIABLE_NAME), [specPath])
          : j.callExpression(j.identifier(CREATE_CLASS_VARIABLE_NAME), classPath.value.arguments)
       ),
-      {comments},
+      {comments}
     );
   };
 


### PR DESCRIPTION
This trailing comma was causing the class transform to fail on my environment even when called with the `--babel` flag.

Environment info:
- macOS 10.12.2
- jscodeshift: v0.3.30
- babel and friends: v6.24.1