### PR TITLE
Added more edge-case handling to PropTypes codemod

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -158,9 +158,17 @@ function replacePropTypesReferences(j, root) {
     .forEach(path => {
       hasModifications = true;
 
-      j(path.parent).replaceWith(
-        j.identifier('PropTypes')
-      );
+      // VariableDeclarator should be removed entirely
+      // eg 'PropTypes = React.PropTypes'
+      if (path.parent.parent.node.type === 'VariableDeclarator') {
+        j(path.parent.parent).remove();
+      } else {
+        // MemberExpression should be updated
+        // eg 'foo = React.PropTypes.string'
+        j(path.parent).replaceWith(
+          j.identifier('PropTypes')
+        );
+      }
     });
 
   return hasModifications;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-from-react-var.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-from-react-var.input.js
@@ -1,0 +1,9 @@
+const React = require('react');
+
+// These are no longer needed after the transform
+const PropTypes = React.PropTypes;
+const {PropTypes} = React;
+
+// This should remain, modified
+const string = React.PropTypes.string;
+const bool = PropTypes.bool;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-from-react-var.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-from-react-var.output.js
@@ -1,0 +1,6 @@
+const PropTypes = require('prop-types');
+const React = require('react');
+
+// This should remain, modified
+const string = PropTypes.string;
+const bool = PropTypes.bool;

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const tests = [
+  'assigned-from-react-var',
   'default-and-named-import',
   'default-import',
   'destructured-proptypes-import',


### PR DESCRIPTION
Previously the codemod might transform:
```js
const PropTypes = React.PropTypes;
```

To:
```js
const PropTypes = PropTypes;
```

I've now added handling for this (and tests)