### PR TITLE
updates create class transform readme to use same path as other codemods

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ jscodeshift -t react-codemod/transforms/sort-comp.js <path>
 
 #### Usage
 ```bash
-jscodeshift -t ./transforms/class.js --mixin-module-name=react-addons-pure-render-mixin --flow=true --pure-component=true --remove-runtime-proptypes=false <path>
+jscodeshift -t react-codemod/transforms/class.js --mixin-module-name=react-addons-pure-render-mixin --flow=true --pure-component=true --remove-runtime-proptypes=false <path>
 ```
 
 ### Recast Options


### PR DESCRIPTION
I noticed typically in the readme the instructions for the usage reference the path using `react-codemod/transforms/`. 

Was there a specific reason for this difference? If not, here as an update that makes it consistent. 