### PR TITLE
Consistently use printOptions

### DIFF
--- a/transforms/React-DOM-to-react-dom-factories.js
+++ b/transforms/React-DOM-to-react-dom-factories.js
@@ -12,6 +12,7 @@
 
 module.exports = function(file, api, options) {
   const j = api.jscodeshift;
+  const printOptions = options.printOptions || { quote: 'single' };
   const root = j(file.source);
 
   let hasModifications;
@@ -187,6 +188,6 @@ module.exports = function(file, api, options) {
   hasModifications = replaceReactDOMReferences(j, root) || hasModifications;
 
   return hasModifications
-    ? root.toSource({ quote: 'single' })
+    ? root.toSource(printOptions)
     : null;
 };

--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -12,6 +12,7 @@
 
 module.exports = function(file, api, options) {
   const j = api.jscodeshift;
+  const printOptions = options.printOptions || { quote: 'single' };
   const root = j(file.source);
 
   const MODULE_NAME = options['module-name'] || 'prop-types';
@@ -230,6 +231,6 @@ module.exports = function(file, api, options) {
   }
 
   return hasModifications
-    ? root.toSource({ quote: 'single' })
+    ? root.toSource(printOptions)
     : null;
 };

--- a/transforms/ReactNative-View-propTypes.js
+++ b/transforms/ReactNative-View-propTypes.js
@@ -73,6 +73,7 @@ const isViewPropTypes = path => (
 module.exports = function(file, api, options) {
   const j = api.jscodeshift;
 
+  const printOptions = options.printOptions || { quote: 'single' };
   let root = j(file.source);
 
   let numMatchedPaths = 0;
@@ -238,6 +239,6 @@ module.exports = function(file, api, options) {
   }
 
   return numMatchedPaths > 0
-    ? root.toSource({ quote: 'single' })
+    ? root.toSource(printOptions)
     : null;
 };

--- a/transforms/create-element-to-jsx.js
+++ b/transforms/create-element-to-jsx.js
@@ -12,6 +12,7 @@
 
 module.exports = function(file, api, options) {
   const j = api.jscodeshift;
+  const printOptions = options.printOptions || {};
   const root = j(file.source);
   const ReactUtils = require('./utils/ReactUtils')(j);
   const encodeJSXTextValue = value =>
@@ -251,7 +252,7 @@ module.exports = function(file, api, options) {
       .size();
 
     if (mutations) {
-      return root.toSource();
+      return root.toSource(printOptions);
     }
   }
 

--- a/transforms/manual-bind-to-arrow.js
+++ b/transforms/manual-bind-to-arrow.js
@@ -21,9 +21,10 @@
  * }
  */
 
-export default function transformer(file, api) {
+export default function transformer(file, api, options) {
   const j = api.jscodeshift;
 
+  const printOptions = options.printOptions || {};
   var root = j(file.source);
 
   // Helper functions to transform a method declaration to an arrow function
@@ -174,7 +175,7 @@ export default function transformer(file, api) {
     });
 
   if (hasChanged) {
-    return transform.toSource();
+    return transform.toSource(printOptions);
   }
   return null;
 }

--- a/transforms/react-to-react-dom.js
+++ b/transforms/react-to-react-dom.js
@@ -54,8 +54,10 @@ function isRequire(path, moduleName) {
   );
 }
 
-module.exports = function(file, api) {
+module.exports = function(file, api, options) {
   var j = api.jscodeshift;
+
+  var printOptions = options.printOptions || {quote: 'single'};
   var root = j(file.source);
 
   [
@@ -393,5 +395,5 @@ module.exports = function(file, api) {
     }
   });
 
-  return root.toSource({quote: 'single'});
+  return root.toSource(printOptions);
 };


### PR DESCRIPTION
The documentation makes reference to the ability to pass `--printOptions`, but this is not strictly observed in all transforms. Since these transformations can potentially affect hundreds of files, it might be annoying to not be able to change recast's defaults, like when it replaces all line-feeds with `CRLF` on Windows.

I tried to honor the existing format in each file with this PR. Since some conventions are not uniform among the existing transformations, I did not use the same format everywhere. Please let me know if you would like for me to adjust this PR as necessary.

I think it is worth noting that it may also be prudent to use something like `Object.assign` and merge the CLI and transform options, rather than just using the CLI options OR the transform's defaults.