### PR TITLE
Fix React-PropTypes-to-prop-types for destructured require

### DIFF
--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/require-destructured-direct.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/require-destructured-direct.input.js
@@ -1,0 +1,9 @@
+const React = require('react');
+const { PropTypes } = require('react');
+
+function Foo(props) {
+  return <div>{props.text}</div>;
+}
+Foo.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/require-destructured-direct.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/require-destructured-direct.output.js
@@ -1,0 +1,9 @@
+const PropTypes = require('prop-types');
+const React = require('react');
+
+function Foo(props) {
+  return <div>{props.text}</div>;
+}
+Foo.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -25,6 +25,7 @@ const tests = [
   'require-alias',
   'require-destructured-multi',
   'require-destructured-only',
+  'require-destructured-direct',
   'require',
 ];
 


### PR DESCRIPTION
I was using React-PropTypes-to-prop-types to convert files in our repo,
and I noticed that this type of construct wouldn't be converted:

  const { PropTypes } = require('react');

To fix this, I modified a function that handled constructs of the
following kind:

  const { PropTypes } = React;

Naming the test fixture was a little hard, since there are other
fixtures testing almost the same thing. I decided to use the term
"direct" to refer to a destructure done "directly" aimed at a require.