### PR TITLE
Retain leading comment fix #147

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -88,6 +88,16 @@ module.exports = function(file, api, options) {
           [j.importDefaultSpecifier(j.identifier(localPropTypesName))],
           j.literal(MODULE_NAME)
         );
+
+        // If there is a leading comment, retain it
+        // https://github.com/facebook/jscodeshift/blob/master/recipes/retain-first-comment.md
+        const firstNode = root.find(j.Program).get('body', 0).node;
+        const {comments} = firstNode;
+        if (comments) {
+          delete firstNode.comments;
+          importStatement.comments = comments;
+        }
+
         j(path).insertBefore(importStatement);
         return;
       }

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/with-top-comment.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/with-top-comment.input.js
@@ -1,0 +1,11 @@
+/**
+ * This is some multiline comment
+ */
+import React, { PropTypes } from 'react';
+
+function FunctionalComponent (props) {
+  return <div>{props.text}</div>;
+}
+FunctionalComponent.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/with-top-comment.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/with-top-comment.output.js
@@ -1,0 +1,13 @@
+/**
+ * This is some multiline comment
+ */
+import PropTypes from 'prop-types';
+
+import React from 'react';
+
+function FunctionalComponent (props) {
+  return <div>{props.text}</div>;
+}
+FunctionalComponent.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -27,6 +27,7 @@ const tests = [
   'require-destructured-only',
   'require-destructured-direct',
   'require',
+  'with-top-comment',
 ];
 
 const defineTest = require('jscodeshift/dist/testUtils').defineTest;


### PR DESCRIPTION
As shown in #147, if the React import is preceded by a comment, the `prop-types` import is printed before it, and not after. This is especially problematic when using the `// @flow` pragma, since it won't be a the top of the file anymore, and therefore won't work. This PR fixes this problem, using the [recipe advised by jscodeshift](https://github.com/facebook/jscodeshift/blob/master/recipes/retain-first-comment.md). However, I do have a whitespace problem, that I can't succeed to fix.

```javascript
/**
 * This is some multiline comment
 */
import React, { PropTypes } from 'react';

// gets converted to 
/**
 * This is some multiline comment
 */
import PropTypes from 'prop-types';

import React from 'react';
```

If someone knows how to fix that, I'll update the PR ASAP. If not, I still do think that this PR could get merged as-is, since the line break should be less bothering than the misplaced comment.