### PR TITLE
mention the --parser=flow option in the README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ APIs.
   * Run `yarn install` in the react-codemod directory
   * `jscodeshift -t <codemod-script> <path>`
   * Use the `-d` option for a dry-run and use `-p` to print the output
-    for comparison
+    for comparison. If you use flowtype, you might also need to use `--parser=flow`.
 
 ### Included Scripts
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ APIs.
     from `https://github.com/reactjs/react-codemod/archive/master.zip`
   * Run `yarn install` in the react-codemod directory
   * `jscodeshift -t <codemod-script> <path>`
-  * Use the `-d` option for a dry-run and use `-p` to print the output
-    for comparison. If you use flowtype, you might also need to use `--parser=flow`.
+  * Use the `-d` option for a dry-run and use `-p` to print the output for comparison.
+  * If you use flowtype, you might also need to use `--parser=flow`.
 
 ### Included Scripts
 


### PR DESCRIPTION
context https://github.com/facebook/jscodeshift/issues/172 : if not using this option, any file that uses `*` flow type syntax will fail.