### PR TITLE
Class transform - Preserve the import declaration when deleting pure mixin import if necessary

### DIFF
--- a/transforms/__testfixtures__/class/class-pure-mixin5.input.js
+++ b/transforms/__testfixtures__/class/class-pure-mixin5.input.js
@@ -1,0 +1,19 @@
+// dont remove me
+var React = require('React'),
+  ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
+
+var ComponentWithOnlyPureRenderMixin = React.createClass({
+  mixins: [ReactComponentWithPureRenderMixin],
+
+  getInitialState: function() {
+    return {
+      counter: this.props.initialNumber + 1,
+    };
+  },
+
+  render: function() {
+    return (
+      <div>{this.state.counter}</div>
+    );
+  },
+});

--- a/transforms/__testfixtures__/class/class-pure-mixin5.output.js
+++ b/transforms/__testfixtures__/class/class-pure-mixin5.output.js
@@ -1,0 +1,14 @@
+// dont remove me
+var React = require('React');
+
+class ComponentWithOnlyPureRenderMixin extends React.PureComponent {
+  state = {
+    counter: this.props.initialNumber + 1,
+  };
+
+  render() {
+    return (
+      <div>{this.state.counter}</div>
+    );
+  }
+}

--- a/transforms/__tests__/class-test.js
+++ b/transforms/__tests__/class-test.js
@@ -36,6 +36,9 @@ defineTest(__dirname, 'class', {
 }, 'class/class-pure-mixin4');
 defineTest(__dirname, 'class', {
   ...pureMixinAlternativeOption,
+}, 'class/class-pure-mixin5');
+defineTest(__dirname, 'class', {
+  ...pureMixinAlternativeOption,
   ...enableFlowOption,
 }, 'class/class-top-comment');
 defineTest(__dirname, 'class', enableFlowOption, 'class/class-initial-state');

--- a/transforms/class.js
+++ b/transforms/class.js
@@ -1275,8 +1275,12 @@ module.exports = (file, api, options) => {
             const bodyNode = path.parentPath.parentPath.parentPath.value;
             const variableDeclarationNode = path.parentPath.parentPath.value;
 
-            removePath = path.parentPath.parentPath;
-            shouldReinsertComment = bodyNode.indexOf(variableDeclarationNode) === 0;
+            if (variableDeclarationNode.declarations.length === 1) {
+              removePath = path.parentPath.parentPath;
+              shouldReinsertComment = bodyNode.indexOf(variableDeclarationNode) === 0;
+            } else {
+              removePath = path;
+            }
           } else {
             const importDeclarationNode = path.value;
             const bodyNode = path.parentPath.value;


### PR DESCRIPTION
As is, the class transformation will indiscriminately delete the declaration when removing the PureMixin dependency.

With this change, it will only delete the declaration if the mixin import was the only declarator for the import declaration.

I've gone ahead and added a corresponding test case.