### PR TITLE
Class transform - Remove React import only if it should be removed

### DIFF
--- a/transforms/__testfixtures__/class/class-prune-react4.input.js
+++ b/transforms/__testfixtures__/class/class-prune-react4.input.js
@@ -1,0 +1,19 @@
+'use strict';
+
+import React, {PropTypes} from 'React';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default React.createClass({
+  mixins: [SomeMixin],
+  propTypes: {
+    foo: PropTypes.string,
+  },
+  render: function() {
+    return <div />;
+  },
+});

--- a/transforms/__testfixtures__/class/class-prune-react4.output.js
+++ b/transforms/__testfixtures__/class/class-prune-react4.output.js
@@ -1,0 +1,24 @@
+'use strict';
+
+import React, {PropTypes} from 'React';
+
+import createReactClass from 'create-react-class';
+
+const SomeMixin = {
+  componentDidMount() {
+    console.log('did mount');
+  },
+};
+
+export default createReactClass({
+  displayName: 'class-prune-react4.input',
+  mixins: [SomeMixin],
+
+  propTypes: {
+    foo: PropTypes.string,
+  },
+
+  render: function() {
+    return <div />;
+  },
+});

--- a/transforms/__tests__/class-test.js
+++ b/transforms/__tests__/class-test.js
@@ -53,6 +53,7 @@ defineTest(__dirname, 'class', {
 defineTest(__dirname, 'class', null, 'class/class-prune-react');
 defineTest(__dirname, 'class', null, 'class/class-prune-react2');
 defineTest(__dirname, 'class', null, 'class/class-prune-react3');
+defineTest(__dirname, 'class', null, 'class/class-prune-react4');
 defineTest(__dirname, 'class', {
   'create-class-module-name': 'createReactClass__deprecated',
   'create-class-variable-name': 'createReactClass__deprecated',

--- a/transforms/class.js
+++ b/transforms/class.js
@@ -1246,7 +1246,10 @@ module.exports = (file, api, options) => {
             shouldReinsertComment = bodyNode.indexOf(importDeclarationNode) === 0;
             removePath = path;
           } else {
-            j(path).find(j.ImportDefaultSpecifier).remove();
+            const paths = j(path).find(j.ImportDefaultSpecifier);
+            if (paths.length) {
+              removePath = j(path).find(j.ImportDefaultSpecifier).paths()[0];
+            }
           }
         }
 


### PR DESCRIPTION
When replacing `React.createClass` with  `createReactClass`, the React import was being erroneously deleted even though JSX existed in the file.

This change ensures that the React import is not erroneously removed. Added a corresponding test case.