### PR TITLE
Fixed PropTypes codemod bug that left invalid variable references

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -208,8 +208,13 @@ module.exports = function(file, api, options) {
         hasModifications = true;
 
         // VariableDeclarator should be removed entirely
-        // eg 'PropTypes = React.PropTypes'
-        if (path.parent.parent.node.type === 'VariableDeclarator') {
+        // eg 'const PropTypes = React.PropTypes'
+        // Don't remove pointers though
+        // eg 'const ReactPropTypes = PropTypes'
+        if (
+          path.parent.parent.node.type === 'VariableDeclarator' &&
+          path.parent.parent.node.id.name === 'PropTypes'
+        ) {
           j(path.parent.parent).remove();
         } else {
           // MemberExpression should be updated

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-to-var-with-different-name.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-to-var-with-different-name.input.js
@@ -1,0 +1,7 @@
+const React = require('react');
+
+const ReactPropTypes = React.PropTypes;
+const PropTypes = React.PropTypes;
+
+const foo = ReactPropTypes.string;
+const bar = PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-to-var-with-different-name.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/assigned-to-var-with-different-name.output.js
@@ -1,0 +1,7 @@
+const PropTypes = require('prop-types');
+
+const React = require('react');
+const ReactPropTypes = PropTypes;
+
+const foo = ReactPropTypes.string;
+const bar = PropTypes.string;

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -12,6 +12,7 @@
 
 const tests = [
   'assigned-from-react-var',
+  'assigned-to-var-with-different-name',
   'default-and-named-import',
   'default-import',
   'destructured-proptypes-import',


### PR DESCRIPTION
While running this codemod against some FB source I discovered a case that wasn't handled correctly:
```js
const React = require('react');
const ReactPropTypes = React.PropTypes;
const string = ReactPropTypes.string;
```
Would get incorrectly converted to:
```js
const React = require('react');
// ReactPropTypes is not defined
const string = ReactPropTypes.string;
```

This PR contains a fix as well as an added test case. Now the codemod only removes pointers that have names that conflict with the import, eg:
```js
const React = require('react');
const ReactPropTypes = React.PropTypes;
const string = ReactPropTypes.string;
```
Will now be converted to:
```js
const PropTypes = require('prop-types');
const React = require('react');
const ReactPropTypes = PropTypes;
const string = ReactPropTypes.string;
```