### PR TITLE
Edge-case fixes for PropTypes codemod

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -83,7 +83,9 @@ module.exports = function(file, api, options) {
   // Program uses ES import syntax
   function useImportSyntax(j, root) {
     return root
-      .find(j.ImportDeclaration)
+      .find(j.ImportDeclaration, {
+        importKind: 'value'
+      })
       .length > 0;
   }
 

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-import.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-import.input.js
@@ -1,0 +1,5 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const object = PropTypes.object;    
+const string = React.PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-import.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-import.output.js
@@ -1,0 +1,5 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const object = PropTypes.object;    
+const string = PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-require.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-require.input.js
@@ -1,0 +1,5 @@
+const PropTypes = require('prop-types');
+const React = require('React');
+
+const object = PropTypes.object;    
+const string = React.PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-require.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-require.output.js
@@ -1,0 +1,5 @@
+const PropTypes = require('prop-types');
+const React = require('React');
+
+const object = PropTypes.object;    
+const string = PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/import-flow-type-with-require.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/import-flow-type-with-require.input.js
@@ -1,0 +1,5 @@
+const React = require('React');
+
+const {PropTypes} = React;
+
+import type {SomeType} from 'SomeModule';

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/import-flow-type-with-require.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/import-flow-type-with-require.output.js
@@ -1,0 +1,4 @@
+const PropTypes = require('prop-types');
+const React = require('React');
+
+import type {SomeType} from 'SomeModule';

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -19,6 +19,7 @@ const tests = [
   'default-import',
   'destructured-proptypes-import',
   'import-alias',
+  'import-flow-type-with-require',
   'mixed-import-and-require',
   'mixed-import-and-require-2',
   'named-parameters',

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -11,6 +11,8 @@
 'use strict';
 
 const tests = [
+  'already-migrated-import',
+  'already-migrated-require',
   'assigned-from-react-var',
   'assigned-to-var-with-different-name',
   'default-and-named-import',


### PR DESCRIPTION
This PR fixes 2 problems observed while running against Facebook code:
* Avoids adding duplicate `prop-types` imports/requires if they already exist. (eg maybe the codemod was already run and then a regression slipped in.)
* Make sure `import type` doesn't give false-positives when it comes to determining whether a given file uses `import` or `require` syntax.

Tests added for both fixes.