### PR TITLE
Update `manual-bind-to-arrow` to support function-bind syntax

### DIFF
--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.input.js
@@ -1,0 +1,7 @@
+class Component extends React.Component {
+  constructor() {
+    super();
+    this.onClick = ::this.onClick;
+  }
+  onClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.output.js
@@ -1,0 +1,3 @@
+class Component extends React.Component {
+  onClick = () => { };
+}

--- a/transforms/__tests__/manual-bind-to-arrow-test.js
+++ b/transforms/__tests__/manual-bind-to-arrow-test.js
@@ -21,6 +21,7 @@ var TESTS = [
   6,
   7,
   8,
+  9,
 ];
 
 TESTS.forEach(test => {

--- a/transforms/manual-bind-to-arrow.js
+++ b/transforms/manual-bind-to-arrow.js
@@ -81,6 +81,8 @@ export default function transformer(file, api) {
       // (this: any).method = this.method.bind(this);
       // or
       // self.method = this.method.bind(this);
+      // or
+      // this.method = ::this.method;
       if (!(
         path.node.left.type === 'MemberExpression' &&
         (
@@ -95,6 +97,7 @@ export default function transformer(file, api) {
         ) &&
         path.node.left.property.type === 'Identifier' &&
         ((
+          // `this.method.bind(this)` syntax
           path.node.right.type === 'CallExpression' &&
           path.node.right.callee.type === 'MemberExpression' &&
           path.node.right.callee.property.type === 'Identifier' &&
@@ -104,6 +107,7 @@ export default function transformer(file, api) {
           path.node.right.callee.object.object.type === 'ThisExpression' &&
           path.node.left.property.name === path.node.right.callee.object.property.name
         ) || (
+          // `::this.method` syntax
           path.node.right.type === 'BindExpression' &&
           path.node.right.callee.type === 'MemberExpression' &&
           path.node.right.callee.object.type === 'ThisExpression' &&

--- a/transforms/manual-bind-to-arrow.js
+++ b/transforms/manual-bind-to-arrow.js
@@ -94,14 +94,22 @@ export default function transformer(file, api) {
           path.node.left.object.expression.type === 'ThisExpression'
         ) &&
         path.node.left.property.type === 'Identifier' &&
-        path.node.right.type === 'CallExpression' &&
-        path.node.right.callee.type === 'MemberExpression' &&
-        path.node.right.callee.property.type === 'Identifier' &&
-        path.node.right.callee.property.name === 'bind' &&
-        path.node.right.callee.object.type === 'MemberExpression' &&
-        path.node.right.callee.object.property.type === 'Identifier' &&
-        path.node.right.callee.object.object.type === 'ThisExpression' &&
-        path.node.left.property.name === path.node.right.callee.object.property.name &&
+        ((
+          path.node.right.type === 'CallExpression' &&
+          path.node.right.callee.type === 'MemberExpression' &&
+          path.node.right.callee.property.type === 'Identifier' &&
+          path.node.right.callee.property.name === 'bind' &&
+          path.node.right.callee.object.type === 'MemberExpression' &&
+          path.node.right.callee.object.property.type === 'Identifier' &&
+          path.node.right.callee.object.object.type === 'ThisExpression' &&
+          path.node.left.property.name === path.node.right.callee.object.property.name
+        ) || (
+          path.node.right.type === 'BindExpression' &&
+          path.node.right.callee.type === 'MemberExpression' &&
+          path.node.right.callee.object.type === 'ThisExpression' &&
+          path.node.right.callee.property.type === 'Identifier' &&
+          path.node.left.property.name === path.node.right.callee.property.name
+        )) &&
         true
       )) {
         return;


### PR DESCRIPTION
In the codemod, `this.foo = ::this.foo` will now be treated the same as `this.foo = this.foo.bind(this)`.