### PR TITLE
Move everything to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,6 @@
     "prepublish": "npm run lint && npm run test"
   },
   "dependencies": {
-    "babel-eslint": "^6.0.5",
-    "babel-jest": "^15.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
-    "eslint": "^2.13.1",
-    "fbjs-scripts": "^0.7.1",
-    "jest": "^17.0.3",
-    "jscodeshift": "^0.3.30",
-    "path": "^0.12.7"
   },
   "jest": {
     "globals": {
@@ -30,6 +21,15 @@
     ]
   },
   "devDependencies": {
-    "eslint-plugin-react": "^5.2.2"
+    "babel-eslint": "^6.0.5",
+    "babel-jest": "^15.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
+    "eslint": "^2.13.1",
+    "eslint-plugin-react": "^5.2.2",
+    "fbjs-scripts": "^0.7.1",
+    "jest": "^17.0.3",
+    "jscodeshift": "^0.3.30",
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
I'm trying to add `react-codemod` as a dev dependency in our repo so that devs have easy access to current versions of these scrips without needing to install them seperately. However, I'm running into issues where the version of Jest in in this project is overriding our version of Jest, and our tests don't work. 

This fixes it by moving all `dependencies` to `devDependencies`. My understanding is that this repo should 'work' without anything installed since it a collection of scripts, and that all the dependencies are only for development. I'm happy to move some back to `dependencies` if I got that wrong. 

