### PR TITLE
Support the `type-annotations` group in sort-comp.

### DIFF
--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -135,6 +135,10 @@ const defaultMethodsOrder = [
 const regExpRegExp = /\/(.*)\/([g|y|i|m]*)/;
 
 function selectorMatches(selector, method) {
+  if (!method.value && method.typeAnnotation && selector === 'type-annotations') {
+    return true;
+  }
+
   if (method.static && selector === 'static-methods') {
     return true;
   }


### PR DESCRIPTION
This PR supports the `type-annotations` group described in https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md