### PR TITLE
Updated Readme to include npm to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ APIs.
 
 ### Setup & Run
 
-1. `yarn global add jscodeshift`
+1. `yarn global add jscodeshift` or `npm install -g jscodeshift`
 1. `git clone https://github.com/reactjs/react-codemod.git` or download a zip file from `https://github.com/reactjs/react-codemod/archive/master.zip`
 1. Run `yarn install` in the react-codemod directory
 1. `jscodeshift -t <codemod-script> <path>`


### PR DESCRIPTION
I am not sure if the 3rd step also needs to have an npm option too, or if npm install means step 2 and 3 isn't needed. Thanks.