### PR TITLE
React-PropTypes-to-prop-types: ignore migrated named import

### DIFF
--- a/transforms/React-PropTypes-to-prop-types.js
+++ b/transforms/React-PropTypes-to-prop-types.js
@@ -220,7 +220,8 @@ module.exports = function(file, api, options) {
       .find(j.Identifier)
       .filter(path => (
         path.node.name === 'PropTypes' &&
-        path.parent.node.type === 'ImportSpecifier'
+        path.parent.node.type === 'ImportSpecifier' &&
+        path.parent.parent.node.source.value === 'react'
       ))
       .forEach(path => {
         hasModifications = true;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-as-import.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-as-import.input.js
@@ -1,0 +1,5 @@
+import { PropTypes as PT } from 'prop-types';
+import React from 'react';
+
+const object = PropTypes.object;
+const string = React.PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-as-import.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-as-import.output.js
@@ -1,0 +1,5 @@
+import { PropTypes as PT } from 'prop-types';
+import React from 'react';
+
+const object = PropTypes.object;
+const string = PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-import.input.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-import.input.js
@@ -1,0 +1,5 @@
+import { PropTypes } from 'prop-types';
+import React from 'react';
+
+const object = PropTypes.object;
+const string = React.PropTypes.string;

--- a/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-import.output.js
+++ b/transforms/__testfixtures__/React-PropTypes-to-prop-types/already-migrated-named-import.output.js
@@ -1,0 +1,5 @@
+import { PropTypes } from 'prop-types';
+import React from 'react';
+
+const object = PropTypes.object;
+const string = PropTypes.string;

--- a/transforms/__tests__/React-PropTypes-to-prop-types-test.js
+++ b/transforms/__tests__/React-PropTypes-to-prop-types-test.js
@@ -11,6 +11,8 @@
 'use strict';
 
 const tests = [
+  'already-migrated-named-as-import',
+  'already-migrated-named-import',
   'already-migrated-import',
   'already-migrated-require',
   'assigned-from-react-var',


### PR DESCRIPTION
Fixes `React-PropTypes-to-prop-types` codemod transforming already migrated named imports incorrectly.

These:
```js
import { PropTypes } from 'prop-types';
```
```js
import { PropTypes as PT } from 'prop-types';
```

Were incorrectly transformed into this:
```js
import 'prop-types';
```

This PR adds a check to transform only nodes importing from `react`, thus ignoring those importing from `prop-types`.

Previously this codemod would basically assume already migrated stuff to use default export:
```js
import PropTypes from 'prop-types';
```

Also adds tests for both cases.

Fixes #187