### PR TITLE
Update ReactUtils.js

### DIFF
--- a/transforms/utils/ReactUtils.js
+++ b/transforms/utils/ReactUtils.js
@@ -158,7 +158,7 @@ module.exports = function(j) {
   const findReactES6ClassDeclaration = path => {
     let classDeclarations = findReactES6ClassDeclarationByParent(path, 'Component');
     if (classDeclarations.size() === 0) {
-      classDeclarations = findReactES6ClassDeclarationByParent(path, 'PureComponent')
+      classDeclarations = findReactES6ClassDeclarationByParent(path, 'PureComponent');
     }
     return classDeclarations;
   };


### PR DESCRIPTION
Add semicolon
Fixes eslint warning
```
react-codemod/transforms/utils/ReactUtils.js
  161:86  warning  Missing semicolon  semi

✖ 1 problem (0 errors, 1 warning)
```
