### PR TITLE
Rename lifecycle invocations too

### DIFF
--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-calling-lifecycles.input.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-calling-lifecycles.input.js
@@ -1,0 +1,3 @@
+const instance = new Component();
+instance.componentWillMount();
+instance.componentDidMount();

--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-calling-lifecycles.output.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-calling-lifecycles.output.js
@@ -1,0 +1,3 @@
+const instance = new Component();
+instance.UNSAFE_componentWillMount();
+instance.componentDidMount();

--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/one-lifecycle-calls-another.input.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/one-lifecycle-calls-another.input.js
@@ -1,0 +1,11 @@
+const React = require('React');
+
+class Component extends React.Component {
+  componentWillMount() {
+    this.componentWillReceiveProps(this.props);
+  }
+  componentWillReceiveProps() {}
+  render() {
+    return null;
+  }
+}

--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/one-lifecycle-calls-another.output.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/one-lifecycle-calls-another.output.js
@@ -1,0 +1,11 @@
+const React = require('React');
+
+class Component extends React.Component {
+  UNSAFE_componentWillMount() {
+    this.UNSAFE_componentWillReceiveProps(this.props);
+  }
+  UNSAFE_componentWillReceiveProps() {}
+  render() {
+    return null;
+  }
+}

--- a/transforms/__tests__/rename-unsafe-lifecycles-test.js
+++ b/transforms/__tests__/rename-unsafe-lifecycles-test.js
@@ -14,6 +14,8 @@ const tests = [
   'arrow-functions',
   'create-react-class',
   'instance-methods',
+  'manually-calling-lifecycles',
+  'one-lifecycle-calls-another',
   'standalone-function',
   'variable-within-class-method',
 ];

--- a/transforms/rename-unsafe-lifecycles.js
+++ b/transforms/rename-unsafe-lifecycles.js
@@ -36,6 +36,19 @@ export default (file, api, options) => {
     }
   };
 
+  const renameDeprecatedCallExpressions = path => {
+    if (!path.node.callee || !path.node.callee.property) {
+      return;
+    }
+
+    const name = path.node.callee.property.name;
+
+    if (DEPRECATED_APIS[name]) {
+      path.node.callee.property.name = DEPRECATED_APIS[name];
+      hasModifications = true;
+    }
+  };
+
   // Class methods
   root
     .find(j.MethodDefinition)
@@ -50,6 +63,11 @@ export default (file, api, options) => {
   root
     .find(j.Property)
     .forEach(renameDeprecatedApis);
+
+  // Function calls
+  root
+    .find(j.CallExpression)
+    .forEach(renameDeprecatedCallExpressions);
 
   return hasModifications
     ? root.toSource(printOptions)


### PR DESCRIPTION
When running this codemod internally I found several places where lifecycles are being invoked manually, either as part of a test or from other lifecycles. I have added a couple of additional tests and updated the codemod to cover this.