### PR TITLE
More broadly rename MemberExpressions

### DIFF
--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-invoked-mixin-methods.input.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-invoked-mixin-methods.input.js
@@ -1,0 +1,20 @@
+const React = require('react');
+const SomeOtherComponent = require('SomeOtherComponent');
+
+class PMTAuthenticationFailureDialog extends React.Component<any, any> {
+  componentDidMount(): void {
+    SomeOtherComponent.mixin.componentDidMount.apply(this);
+  }
+
+  componentWillMount(): void {
+    SomeOtherComponent.mixin.componentWillMount.apply(this);
+  }
+
+  componentWillUnmount(): void {
+    SomeOtherComponent.mixin.componentWillUnmount.apply(this);
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-invoked-mixin-methods.output.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/manually-invoked-mixin-methods.output.js
@@ -1,0 +1,20 @@
+const React = require('react');
+const SomeOtherComponent = require('SomeOtherComponent');
+
+class PMTAuthenticationFailureDialog extends React.Component<any, any> {
+  componentDidMount(): void {
+    SomeOtherComponent.mixin.componentDidMount.apply(this);
+  }
+
+  UNSAFE_componentWillMount(): void {
+    SomeOtherComponent.mixin.UNSAFE_componentWillMount.apply(this);
+  }
+
+  componentWillUnmount(): void {
+    SomeOtherComponent.mixin.componentWillUnmount.apply(this);
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/transforms/__tests__/rename-unsafe-lifecycles-test.js
+++ b/transforms/__tests__/rename-unsafe-lifecycles-test.js
@@ -15,6 +15,7 @@ const tests = [
   'create-react-class',
   'instance-methods',
   'manually-calling-lifecycles',
+  'manually-invoked-mixin-methods',
   'one-lifecycle-calls-another',
   'standalone-function',
   'variable-within-class-method',

--- a/transforms/rename-unsafe-lifecycles.js
+++ b/transforms/rename-unsafe-lifecycles.js
@@ -37,14 +37,10 @@ export default (file, api, options) => {
   };
 
   const renameDeprecatedCallExpressions = path => {
-    if (!path.node.callee || !path.node.callee.property) {
-      return;
-    }
-
-    const name = path.node.callee.property.name;
+    const name = path.node.property.name;
 
     if (DEPRECATED_APIS[name]) {
-      path.node.callee.property.name = DEPRECATED_APIS[name];
+      path.node.property.name = DEPRECATED_APIS[name];
       hasModifications = true;
     }
   };
@@ -66,7 +62,7 @@ export default (file, api, options) => {
 
   // Function calls
   root
-    .find(j.CallExpression)
+    .find(j.MemberExpression)
     .forEach(renameDeprecatedCallExpressions);
 
   return hasModifications


### PR DESCRIPTION
Follow-up to #198

When running this codemod internally I found several additional places manually invoking lifecycles like `SomeComponent.componentDidMount.apply()` so the codemod has been updated to handle this case also.

So I've changed the codemod from renaming `CallExpression`s (eg `instance.method()`) to broader `MemberExpression`s (eg `instance.method()` _and_ `instance.method.apply()`).

Additional tests have been added.