### PR TITLE
Do not consider history.replaceState() deprecated

### DIFF
--- a/transforms/class.js
+++ b/transforms/class.js
@@ -179,6 +179,23 @@ module.exports = (file, api, options) => {
       (acc, name) =>
         acc + j(classPath)
           .find(j.Identifier, {name})
+          .filter(path => {
+            // Do not consider history.replaceState() deprecated
+            let correctContext = true;
+
+            if (
+              name === 'replaceState' &&
+              path.parentPath &&
+              path.parentPath.value &&
+              path.parentPath.value.object &&
+              path.parentPath.value.object.name &&
+              path.parentPath.value.object.name === 'history'
+            ) {
+              correctContext = false;
+            }
+
+            return correctContext;
+          })
           .size(),
       0
     ) > 0;


### PR DESCRIPTION
This is a fix for #123. Potentially this could be made more generic by checking `path.parentPath.value.type` and check if it's CallExpression or something else, but in order to avoid potential false positives I decided to just make the fix for this specific case.

Comments welcome! This issue was preventing us from converting some of our classes, and I would be happy if this issue could be resolved and potentially help others.