### PR TITLE
Updated so default order to include React ^16.3 lifecycle methods.

### DIFF
--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -200,9 +200,7 @@ function getMethodsOrderFromEslint(filePath) {
   const CLIEngine = require('eslint').CLIEngine;
   const cli = new CLIEngine({ useEslintrc: true });
   try {
-    console.log('filePath', filePath);
     const config = cli.getConfigForFile(filePath);
-    console.log('config', config);
     const {rules} = config;
     const sortCompRules = rules['react/sort-comp'];
     order = sortCompRules && sortCompRules[1].order;

--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -110,19 +110,24 @@ const defaultMethodsOrder = [
   'contextTypes',
   'childContextTypes',
   'mixins',
-  'statics',
   'defaultProps',
   'constructor',
   'getDefaultProps',
   'state',
   'getInitialState',
   'getChildContext',
+  'getDerivedStateFromProps',
   'componentWillMount',
+  'UNSAFE_componentWillMount',
   'componentDidMount',
   'componentWillReceiveProps',
+  'UNSAFE_componentWillReceiveProps',
   'shouldComponentUpdate',
   'componentWillUpdate',
+  'UNSAFE_componentWillUpdate',
+  'getSnapshotBeforeUpdate',
   'componentDidUpdate',
+  'componentDidCatch',
   'componentWillUnmount',
   '/^on.+$/',
   '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
@@ -134,12 +139,23 @@ const defaultMethodsOrder = [
 // FROM https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/sort-comp.js
 const regExpRegExp = /\/(.*)\/([g|y|i|m]*)/;
 
+var count = 0;
+
 function selectorMatches(selector, method) {
-  if (method.static && selector === 'static-methods') {
+  const methodName = method.key.name;
+
+  if (
+    method.static &&
+    selector === 'static-methods' &&
+    ['propTypes', 'defaultProps'].indexOf(methodName) === -1 &&
+    !/^(get|set)/.test(methodName)
+  ) {
+
+
+    if (!count) { console.trace(); }
+    count ++;
     return true;
   }
-
-  const methodName = method.key.name;
 
   if (selector === methodName) {
     return true;
@@ -152,6 +168,8 @@ function selectorMatches(selector, method) {
     const selectorRe = new RegExp(match[1], match[2]);
     return selectorRe.test(methodName);
   }
+
+
 
   return false;
 }
@@ -182,7 +200,9 @@ function getMethodsOrderFromEslint(filePath) {
   const CLIEngine = require('eslint').CLIEngine;
   const cli = new CLIEngine({ useEslintrc: true });
   try {
+    console.log('filePath', filePath);
     const config = cli.getConfigForFile(filePath);
+    console.log('config', config);
     const {rules} = config;
     const sortCompRules = rules['react/sort-comp'];
     order = sortCompRules && sortCompRules[1].order;
@@ -193,7 +213,8 @@ function getMethodsOrderFromEslint(filePath) {
 }
 
 function getMethodsOrder(fileInfo, options) {
-  return options.methodsOrder
+  const order = options.methodsOrder
     || getMethodsOrderFromEslint(fileInfo.path)
     || defaultMethodsOrder;
+  return order;
 }

--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -139,8 +139,6 @@ const defaultMethodsOrder = [
 // FROM https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/sort-comp.js
 const regExpRegExp = /\/(.*)\/([g|y|i|m]*)/;
 
-var count = 0;
-
 function selectorMatches(selector, method) {
   const methodName = method.key.name;
 
@@ -150,10 +148,6 @@ function selectorMatches(selector, method) {
     ['propTypes', 'defaultProps'].indexOf(methodName) === -1 &&
     !/^(get|set)/.test(methodName)
   ) {
-
-
-    if (!count) { console.trace(); }
-    count ++;
     return true;
   }
 
@@ -168,8 +162,6 @@ function selectorMatches(selector, method) {
     const selectorRe = new RegExp(match[1], match[2]);
     return selectorRe.test(methodName);
   }
-
-
 
   return false;
 }


### PR DESCRIPTION
Updated so that the default order includes the new React lifecycle methods.  Also, according to the latest eslint rules for React 16.3 and higher, static methods no longer always have to be at the top.  It depends on the name of the static method.  For instance, one of the new lifecycle methods, getDerivedStateFromProps, is a static method that must go under the constructor.  Static methods that start with get, set, must go under the lifecycle methods and before "everything else"