### PR TITLE
Fix forgotten PureComponent in ReactUtils

### DIFF
--- a/transforms/utils/ReactUtils.js
+++ b/transforms/utils/ReactUtils.js
@@ -145,7 +145,7 @@ module.exports = function(j) {
           },
           property: {
             type: 'Identifier',
-            name: 'Component',
+            name: parentClassName,
           },
         },
       };


### PR DESCRIPTION
Hi guys.
I was implementing a `sort-comp` fixer in the project when noticed that PureComponent is always skipped. This happens because `findReactES6ClassDeclarationByParent` searches only for occurrences of a `Component` even if a `PureComponent` was passed.