### PR TITLE
POC - npx react-codemod <transform> <path/to/src>

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx react-codemod manual-bind-to-arrow <path>
 #### `pure-component`
 
 Converts ES6 classes that only have a render method, only have safe properties
-(statics and props), and do not have refs to Stateless Functional Components.
+(statics and props), and do not have refs to Functional Components.
 
 Option `useArrows` converts to arrow function. Converts to `function` by default.  
 Option `destructuring` will destructure props in the argument where it is safe to do so.  

--- a/README.md
+++ b/README.md
@@ -4,27 +4,23 @@ This repository contains a collection of codemod scripts for use with
 [JSCodeshift](https://github.com/facebook/jscodeshift) that help update React
 APIs.
 
-### Setup & Run
-
-1. `yarn global add jscodeshift`
-1. `git clone https://github.com/reactjs/react-codemod.git` or download a zip file from `https://github.com/reactjs/react-codemod/archive/master.zip`
-1. Run `yarn install` in the react-codemod directory
-1. `jscodeshift -t <codemod-script> <path>`
-   * `codemod-script` - path to the transform file, see available scripts below;
+### Usage
+`npx react-codemod <codemod> <path>`
+   * `codemod` - name of transform, see available transforms below;
    * `path` - files or directory to transform;
    * use the `-d` option for a dry-run and use `-p` to print the output for comparison;
    * use the `--extensions` option if your files have different extensions than `.js` (for example, `--extensions js,jsx`);
    * if you use flowtype, you might also need to use `--parser=flow`;
    * see all available [jscodeshift options](https://github.com/facebook/jscodeshift#usage-cli).
 
-### Included Scripts
+### Included Transforms
 
 #### `create-element-to-jsx`
 
 Converts calls to `React.createElement` into JSX elements.
 
 ```sh
-jscodeshift -t react-codemod/transforms/create-element-to-jsx.js <path>
+npx react-codemod create-element-to-jsx <path>
 ```
 
 #### `error-boundaries`
@@ -32,7 +28,7 @@ jscodeshift -t react-codemod/transforms/create-element-to-jsx.js <path>
 Renames the experimental `unstable_handleError` lifecycle hook to `componentDidCatch`.
 
 ```sh
-jscodeshift -t react-codemod/transforms/error-boundaries.js <path>
+npx react-codemod error-boundaries <path>
 ```
 
 #### `findDOMNode`
@@ -44,7 +40,7 @@ the component instance or its refs. You can use this script to update most calls
 to `getDOMNode` and then manually go through the remaining calls.
 
 ```sh
-jscodeshift -t react-codemod/transforms/findDOMNode.js <path>
+npx react-codemod findDOMNode <path>
 ```
 
 #### `manual-bind-to-arrow`
@@ -52,7 +48,7 @@ jscodeshift -t react-codemod/transforms/findDOMNode.js <path>
 Converts manual function bindings in a class (e.g., `this.f = this.f.bind(this)`) to arrow property initializer functions (e.g., `f = () => {}`).
 
 ```sh
-jscodeshift -t react-codemod/transforms/manual-bind-to-arrow.js <path>
+npx react-codemod manual-bind-to-arrow <path>
 ```
 
 #### `pure-component`
@@ -65,7 +61,7 @@ Option `destructuring` will destructure props in the argument where it is safe t
 Note these options must be passed on the command line as `--useArrows=true` (`--useArrows` won't work)
 
 ```sh
-jscodeshift -t react-codemod/transforms/pure-component.js <path> [--useArrows=true --destructuring=true]
+npx react-codemod pure-component <path> [--useArrows=true --destructuring=true]
 ```
 
 #### `pure-render-mixin`
@@ -76,7 +72,7 @@ class. NOTE: This currently only works if you are using the master version
 (>0.13.1) of React as it is using `React.addons.shallowCompare`
 
 ```sh
-jscodeshift -t react-codemod/transforms/pure-render-mixin.js <path>
+npx react-codemod pure-render-mixin <path>
 ```
 
  * If `--mixin-name=<name>` is specified it will look for the specified name
@@ -89,7 +85,7 @@ jscodeshift -t react-codemod/transforms/pure-render-mixin.js <path>
 Replaces `React.PropTypes` references with `prop-types` and adds the appropriate `import` or `require` statement. This codemod is intended for React 15.5+.
 
 ```sh
-jscodeshift -t react-codemod/transforms/React-PropTypes-to-prop-types.js <path>
+npx react-codemod React-PropTypes-to-prop-types <path>
 ```
 
   * In addition to running the above codemod you will also need to install the 'prop-types' NPM package.
@@ -99,7 +95,7 @@ jscodeshift -t react-codemod/transforms/React-PropTypes-to-prop-types.js <path>
 Adds "UNSAFE_" prefix for deprecated lifecycle hooks. (For more information about this codemod, see [React RFC #6](https://github.com/reactjs/rfcs/pull/6))
 
 ```sh
-jscodeshift -t react-codemod/transforms/rename-unsafe-lifecycles.js <path>
+npx react-codemod rename-unsafe-lifecycles <path>
 ```
 
 #### `react-to-react-dom`
@@ -111,7 +107,7 @@ not support ES6 modules or other non-CommonJS systems. We recommend performing
 the `findDOMNode` conversion first.
 
 ```sh
-jscodeshift -t react-codemod/transforms/react-to-react-dom.js <path>
+npx react-codemod react-to-react-dom <path>
 ```
 
   * After running the automated codemod, you may want to run a regex-based
@@ -125,7 +121,7 @@ jscodeshift -t react-codemod/transforms/react-to-react-dom.js <path>
 Replaces `View.propTypes` references with `ViewPropTypes` and adds the appropriate `import` or `require` statement. This codemod is intended for ReactNative 44+.
 
 ```sh
-jscodeshift -t react-codemod/transforms/ReactNative-View-propTypes.js <path>
+npx react-codemod ReactNative-View-propTypes <path>
 ```
 
 #### `sort-comp`
@@ -136,7 +132,7 @@ rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/so
 guide](https://github.com/airbnb/javascript/blob/7684892951ef663e1c4e62ad57d662e9b2748b9e/packages/eslint-config-airbnb/rules/react.js#L122-L134).
 
 ```sh
-jscodeshift -t react-codemod/transforms/sort-comp.js <path>
+npx react-codemod sort-comp <path>
 ```
 
 ### Explanation of the new ES2015 class transform with property initializers
@@ -181,7 +177,7 @@ jscodeshift -t react-codemod/transforms/sort-comp.js <path>
 
 #### Usage
 ```bash
-jscodeshift -t ./transforms/class.js --mixin-module-name=react-addons-pure-render-mixin --flow=true --pure-component=true --remove-runtime-proptypes=false <path>
+npx react-codemod class --mixin-module-name=react-addons-pure-render-mixin --flow=true --pure-component=true --remove-runtime-proptypes=false <path>
 ```
 
 ### Recast Options
@@ -190,7 +186,7 @@ Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through the `printOptions` command line argument
 
 ```sh
-jscodeshift -t transform.js <path> --printOptions='{"quote":"double"}'
+npx react-codemod <transform> <path> --printOptions='{"quote":"double"}'
 ```
 
 ### Support and Contributing

--- a/bin/react-codemod.js
+++ b/bin/react-codemod.js
@@ -20,7 +20,8 @@ const usage = `npx react-codemod <transform> <path/to/code>\n`;
 if (!transform || transforms.indexOf(transform) === -1) {
   console.log(usage);
   console.error(
-    'missing/invalid transform name. Pick one of:\n' + transforms.join('\n')
+    'missing/invalid transform name. Pick one of:\n' +
+      transforms.map(x => '- ' + x).join('\n')
   );
   process.exit(1);
 }
@@ -30,11 +31,14 @@ if (!dest) {
   process.exit(1);
 }
 
-childProcess.execSync(
-  `npm run jscodeshift -- -t transforms/${transform}.js ${path.join(
-    currentDir,
-    dest
-  )} ${[...process.argv].slice(4).join(' ')}`
-);
-
-// warn if node_modules?
+const cmd = `npm run jscodeshift -- -t ${path.join(
+  'transforms',
+  transform + '.js'
+)} ${path.join(
+  currentDir,
+  dest
+)} --verbose=2 --ignore-pattern= node_modules ${[...process.argv]
+  .slice(4)
+  .join(' ')}`;
+console.log('running', cmd);
+childProcess.execSync(cmd);

--- a/bin/react-codemod.js
+++ b/bin/react-codemod.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// react-codemod name-of-transform path/to/src
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const currentDir = process.cwd();
+process.chdir(__dirname);
+
+const transforms = fs
+  .readdirSync('../transforms')
+  .filter(x => x.slice(-3) === '.js')
+  .map(x => x.slice(0, -3));
+
+const transform = process.argv[2];
+const dest = process.argv[3];
+const usage = `npx react-codemod <transform> <path/to/code>\n`;
+if (!transform || transforms.indexOf(transform) === -1) {
+  console.log(usage);
+  console.error(
+    'missing/invalid transform name. Pick one of:\n' + transforms.join('\n')
+  );
+  process.exit(1);
+}
+if (!dest) {
+  console.log(usage);
+  console.error('missing path to code.');
+  process.exit(1);
+}
+
+childProcess.execSync(
+  `npm run jscodeshift -- -t transforms/${transform}.js ${path.join(
+    currentDir,
+    dest
+  )} ${[...process.argv].slice(4).join(' ')}`
+);
+
+// warn if node_modules?

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint .",
-    "prepublish": "npm run lint && npm run test"
+    "prepublish": "npm run lint && npm run test",
+    "jscodeshift": "jscodeshift"
   },
   "dependencies": {
     "babel-eslint": "^6.0.5",
@@ -31,5 +32,8 @@
   },
   "devDependencies": {
     "eslint-plugin-react": "^5.2.2"
+  },
+  "bin": {
+    "react-codemod": "./bin/react-codemod.js"
   }
 }


### PR DESCRIPTION
An improvement to actually using these codemods. You should be able to `npx react-codemod <transform> path/to/src` and it should Just Work™️. Also updates the docs to prefer this version.

Did it as a quick hack so I could show during the meeting, happy to work on it further if it looks good. Would be good to point to in 16.9.0 release notes as well. 