### PR TITLE
fix: add missing transformer option React-PropTypes-to-prop-types

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -150,6 +150,11 @@ const TRANSFORMER_INQUIRER_CHOICES = [
   },
   {
     name:
+      'React-PropTypes-to-prop-types: Replaces React.PropTypes references with prop-types and adds the appropriate import or require statement',
+    value: 'React-PropTypes-to-prop-types'
+  },
+  {
+    name:
       'ReactNative-View-propTypes: Replaces View.propTypes references with ViewPropTypes (for ReactNative 44+) ',
     value: 'ReactNative-View-propTypes'
   },

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -150,7 +150,7 @@ const TRANSFORMER_INQUIRER_CHOICES = [
   },
   {
     name:
-      'React-PropTypes-to-prop-types: Replaces React.PropTypes references with prop-types and adds the appropriate import or require statement',
+      'React-PropTypes-to-prop-types: Replaces React.PropTypes references with prop-types',
     value: 'React-PropTypes-to-prop-types'
   },
   {


### PR DESCRIPTION
`React-PropTypes-to-prop-types` was missing in the `TRANSFORMER_INQUIRER_CHOICES` list. This commit fixes that. 

Fixes #230 