### PR TITLE
support typescript in rename-unsafe-lifecycles

### DIFF
--- a/transforms/rename-unsafe-lifecycles.js
+++ b/transforms/rename-unsafe-lifecycles.js
@@ -50,6 +50,11 @@ export default (file, api, options) => {
     .find(j.MethodDefinition)
     .forEach(renameDeprecatedApis);
 
+  // Class methods - typescript 
+  root
+    .find(j.ClassMethod)
+    .forEach(renameDeprecatedApis);
+
   // Arrow functions
   root
     .find(j.ClassProperty)


### PR DESCRIPTION
Thanks to @skovy in https://github.com/reactjs/react-codemod/pull/228, we have a fix for this codemod not working correctly for typescript files. Making this a separate commit/PR to unblock publishing.