### PR TITLE
Add TypeScript tests for the rename-unsafe-lifecycles transform

### DIFF
--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/typescript/class.tsx.input.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/typescript/class.tsx.input.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+class Component extends React.Component {
+  public componentWillMount() {}
+  public componentDidMount() {}
+  public componentWillReceiveProps() {}
+  public shouldComponentUpdate() {}
+  public componentWillUpdate() {}
+  public componentDidUpdate() {}
+  public componentWillUnmount() {}
+  public render() {
+    return null;
+  }
+}

--- a/transforms/__testfixtures__/rename-unsafe-lifecycles/typescript/class.tsx.output.js
+++ b/transforms/__testfixtures__/rename-unsafe-lifecycles/typescript/class.tsx.output.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+class Component extends React.Component {
+  public UNSAFE_componentWillMount() {}
+  public componentDidMount() {}
+  public UNSAFE_componentWillReceiveProps() {}
+  public shouldComponentUpdate() {}
+  public UNSAFE_componentWillUpdate() {}
+  public componentDidUpdate() {}
+  public componentWillUnmount() {}
+  public render() {
+    return null;
+  }
+}

--- a/transforms/__tests__/rename-unsafe-lifecycles-test.js
+++ b/transforms/__tests__/rename-unsafe-lifecycles-test.js
@@ -10,12 +10,6 @@
 
 'use strict';
 
-jest.mock('../rename-unsafe-lifecycles', () => {
-  return Object.assign(require.requireActual('../rename-unsafe-lifecycles'), {
-    parser: 'flow'
-  });
-});
-
 const tests = [
   'arrow-functions',
   'create-react-class',
@@ -30,12 +24,53 @@ const tests = [
 const defineTest = require('jscodeshift/dist/testUtils').defineTest;
 
 describe('rename-unsafe-lifecycles', () => {
-  tests.forEach(test =>
+  describe('flow', () => {
+    beforeEach(() => {
+      jest.mock('../rename-unsafe-lifecycles', () => {
+        return Object.assign(
+          require.requireActual('../rename-unsafe-lifecycles'),
+          {
+            parser: 'flow'
+          }
+        );
+      });
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    tests.forEach(test =>
+      defineTest(
+        __dirname,
+        'rename-unsafe-lifecycles',
+        null,
+        `rename-unsafe-lifecycles/${test}`
+      )
+    );
+  });
+
+  describe('typescript', () => {
+    beforeEach(() => {
+      jest.mock('../rename-unsafe-lifecycles', () => {
+        return Object.assign(
+          require.requireActual('../rename-unsafe-lifecycles'),
+          {
+            parser: 'tsx'
+          }
+        );
+      });
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
     defineTest(
       __dirname,
       'rename-unsafe-lifecycles',
       null,
-      `rename-unsafe-lifecycles/${test}`
-    )
-  );
+      'rename-unsafe-lifecycles/typescript/class.tsx'
+    );
+  });
 });


### PR DESCRIPTION
Only the tests from https://github.com/reactjs/react-codemod/pull/228.

The transform has to be mocked because `jscodeshift` doesn't support testing other parsers/file extensions.

I named the examples `class.tsx.input.js` (must be `js` to match what `jscodeshift` expects) but still keep the `tsx` to help show that it's expected to actually be a TSX file (and can be if something like https://github.com/facebook/jscodeshift/pull/332 is merged). Happy to remove this and keep it only `class.input.js` 😕