### PR TITLE
Add support for handling groups for method ordering in sort-comp codemod

### DIFF
--- a/transforms/__testfixtures__/custom-sort-group/.eslintrc
+++ b/transforms/__testfixtures__/custom-sort-group/.eslintrc
@@ -1,0 +1,18 @@
+---
+plugins:
+  - react
+rules:
+  no-undef: 0
+  no-unused-vars: 0
+  react/sort-comp:
+    - 0
+    - order:
+      - lifecycle
+      - everything-else
+      - rendering
+      groups:
+        lifecycle:
+        - componentDidMount
+        rendering:
+        - "/^render.+$/"
+        - render

--- a/transforms/__testfixtures__/custom-sort-group/custom-sort-group.input.js
+++ b/transforms/__testfixtures__/custom-sort-group/custom-sort-group.input.js
@@ -1,0 +1,24 @@
+var React = require('react/addons');
+
+// comment above createClass
+var MyComponent = React.createClass({
+  render: function() {
+    return renderChild();
+  },
+
+  mixins: [PureRenderMixin],
+
+  // comment on componentDidMount
+  componentDidMount() {},
+
+  myOwnMethod(foo) {
+    // comment within method
+  },
+
+  renderChild: function() {
+    return <div />;
+  },
+});
+
+/* comment at end */
+module.exports = MyComponent;

--- a/transforms/__testfixtures__/custom-sort-group/custom-sort-group.output.js
+++ b/transforms/__testfixtures__/custom-sort-group/custom-sort-group.output.js
@@ -1,0 +1,24 @@
+var React = require('react/addons');
+
+// comment above createClass
+var MyComponent = React.createClass({
+  // comment on componentDidMount
+  componentDidMount() {},
+
+  mixins: [PureRenderMixin],
+
+  myOwnMethod(foo) {
+    // comment within method
+  },
+
+  renderChild: function() {
+    return <div />;
+  },
+
+  render: function() {
+    return renderChild();
+  },
+});
+
+/* comment at end */
+module.exports = MyComponent;

--- a/transforms/__tests__/custom-sort-group.js
+++ b/transforms/__tests__/custom-sort-group.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+// The test fixtures for this are in their own dir so it can customize eslint with method grouping.
+defineTest(__dirname, 'sort-comp', null, 'custom-sort-group/custom-sort-group');

--- a/transforms/sort-comp.js
+++ b/transforms/sort-comp.js
@@ -192,18 +192,35 @@ function getCorrectIndex(methodsOrder, method) {
 }
 
 function getMethodsOrderFromEslint(filePath) {
-  let order;
   const CLIEngine = require('eslint').CLIEngine;
   const cli = new CLIEngine({ useEslintrc: true });
   try {
     const config = cli.getConfigForFile(filePath);
     const {rules} = config;
     const sortCompRules = rules['react/sort-comp'];
-    order = sortCompRules && sortCompRules[1].order;
+    const ruleConfig = sortCompRules && sortCompRules[1];
+    if (!ruleConfig) {
+      return null;
+    }
+
+    const order = ruleConfig.order;
+    const groups = ruleConfig.groups || {};
+
+    let resolvedOrder = [];
+    for (let i = 0; i < order.length; i++) {
+      const entry = order[i];
+      if (groups[entry]) {
+        resolvedOrder = resolvedOrder.concat(groups[entry]);
+      } else {
+        resolvedOrder.push(entry);
+      }
+    }
+
+    return resolvedOrder;
   } catch (e) {
     // unable to get config for file
   }
-  return order;
+  return null;
 }
 
 function getMethodsOrder(fileInfo, options) {


### PR DESCRIPTION
Picking the logic from https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/sort-comp.js#L59 to support groups with order. Airbnb style guide also uses groups and react-codemod doesn't sort methods properly when defined using them.