### PR TITLE
Issues/181 : manual-bind-to-arrow does not clean up constructor binds when the same bind occurs multiple times

### DIFF
--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow10.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow10.input.js
@@ -9,7 +9,7 @@ class Component extends React.Component {
 class Component2 extends React.Component {
     constructor() {
         super();
-        this.didClick = this.didClick.bind(this);
+        this.onClick = this.onClick.bind(this);
     }
-    didClick() { }
+    onClick() { }
 }

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow10.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow10.output.js
@@ -3,5 +3,5 @@ class Component extends React.Component {
 }
 
 class Component2 extends React.Component {
-    didClick = () => { };
+    onClick = () => { };
 }

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.input.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.input.js
@@ -1,0 +1,15 @@
+class Component extends React.Component {
+    constructor() {
+        super();
+        this.onClick = this.onClick.bind(this);
+    }
+    onClick() { }
+}
+
+class Component2 extends React.Component {
+    constructor() {
+        super();
+        this.onClick = this.onClick.bind(this);
+    }
+    onClick() { }
+}

--- a/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.output.js
+++ b/transforms/__testfixtures__/manual-bind-to-arrow/manual-bind-to-arrow9.output.js
@@ -1,0 +1,7 @@
+class Component extends React.Component {
+    onClick = () => { };
+}
+
+class Component2 extends React.Component {
+    onClick = () => { };
+}

--- a/transforms/__tests__/manual-bind-to-arrow-test.js
+++ b/transforms/__tests__/manual-bind-to-arrow-test.js
@@ -25,7 +25,8 @@ var TESTS = [
   6,
   7,
   8,
-  9
+  9,
+  10
 ];
 
 TESTS.forEach(test => {

--- a/transforms/__tests__/manual-bind-to-arrow-test.js
+++ b/transforms/__tests__/manual-bind-to-arrow-test.js
@@ -25,6 +25,7 @@ var TESTS = [
   6,
   7,
   8,
+  9
 ];
 
 TESTS.forEach(test => {

--- a/transforms/manual-bind-to-arrow.js
+++ b/transforms/manual-bind-to-arrow.js
@@ -107,7 +107,9 @@ export default function transformer(file, api, options) {
 
     // Find the method() declaration and replace it with an arrow function
     var methodName = path.node.left.property.name;
-    var methods = root
+
+    const componentDecl = methodPath.parentPath;
+    var methods = j(componentDecl)
       .find(j.MethodDefinition)
       .filter(
         path =>
@@ -121,7 +123,7 @@ export default function transformer(file, api, options) {
       return;
     }
     methods.replaceWith(path => createArrowProperty(path.node));
-
+    
     // Remove the line
     // this.method = this.method.bind(this);
     j(path.parentPath).remove();


### PR DESCRIPTION
- Created a test with two components declared and bound functions with different names. This passes.
- Created a test with two components declared and bound functions with same name. This fails.

Added fix to scope the method/constructor removal to the corresponding component declaration instead of the root of the file.