### PR TITLE
Fix pure component transform edge cases

### DIFF
--- a/transforms/__testfixtures__/pure-component.input.js
+++ b/transforms/__testfixtures__/pure-component.input.js
@@ -31,6 +31,12 @@ class ImpureWithRef extends React.Component {
   }
 }
 
+class PureWithoutProps extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
 class PureWithTypes extends React.Component {
   props: { foo: string };
   render() {
@@ -65,7 +71,7 @@ class PureWithPropTypes extends React.Component {
   static propTypes = { foo: React.PropTypes.string };
   static foo = 'bar';
   render() {
-    return <div />;
+    return <div>{this.props.foo}</div>;
   }
 }
 
@@ -73,7 +79,7 @@ class PureWithPropTypes2 extends React.Component {
   props: { foo: string };
   static propTypes = { foo: React.PropTypes.string };
   render() {
-    return <div />;
+    return <div>{this.props.foo}</div>;
   }
 }
 

--- a/transforms/__testfixtures__/pure-component.output.js
+++ b/transforms/__testfixtures__/pure-component.output.js
@@ -29,6 +29,10 @@ class ImpureWithRef extends React.Component {
   }
 }
 
+function PureWithoutProps() {
+  return <div />;
+}
+
 function PureWithTypes(props: { foo: string }) {
   return <div className={props.foo} />;
 }
@@ -54,14 +58,14 @@ class ImpureClassPropertyWithTypes extends React.Component {
 }
 
 function PureWithPropTypes(props) {
-  return <div />;
+  return <div>{props.foo}</div>;
 }
 
 PureWithPropTypes.propTypes = { foo: React.PropTypes.string };
 PureWithPropTypes.foo = 'bar';
 
 function PureWithPropTypes2(props: { foo: string }) {
-  return <div />;
+  return <div>{props.foo}</div>;
 }
 
 PureWithPropTypes2.propTypes = { foo: React.PropTypes.string };

--- a/transforms/__testfixtures__/pure-component2.input.js
+++ b/transforms/__testfixtures__/pure-component2.input.js
@@ -21,6 +21,12 @@ class Impure extends React.Component {
   }
 }
 
+class PureWithoutProps extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
 class PureWithTypes extends React.Component {
   props: { foo: string };
   render() {
@@ -40,7 +46,7 @@ class PureWithTypes2 extends React.Component {
 class PureWithPropTypes extends React.Component {
   static propTypes = { foo: React.PropTypes.string };
   render() {
-    return <div />;
+    return <div>{this.props.foo}</div>;
   }
 }
 

--- a/transforms/__testfixtures__/pure-component2.output.js
+++ b/transforms/__testfixtures__/pure-component2.output.js
@@ -19,6 +19,10 @@ class Impure extends React.Component {
   }
 }
 
+const PureWithoutProps = () => {
+  return <div />;
+};
+
 const PureWithTypes = (props: { foo: string }) => {
   return <div className={props.foo} />;
 };
@@ -30,7 +34,7 @@ const PureWithTypes2 = (props: Props) => {
 };
 
 const PureWithPropTypes = props => {
-  return <div />;
+  return <div>{props.foo}</div>;
 };
 
 PureWithPropTypes.propTypes = { foo: React.PropTypes.string };

--- a/transforms/pure-component.js
+++ b/transforms/pure-component.js
@@ -214,16 +214,17 @@ module.exports = function(file, api, options) {
       );
   };
 
-  const build = useArrows => (name, body, typeAnnotation, destructure) => {
+  const build = useArrows => (name, body, typeAnnotation, destructure, hasThisDotProps) => {
     const identifier = j.identifier(name);
     const propsIdentifier = buildIdentifierWithTypeAnnotation(
       'props',
       typeAnnotation
     );
-    const propsArg = [
+
+    const propsArg = hasThisDotProps ? [
       (destructure && destructureProps(j(body), typeAnnotation)) ||
         propsIdentifier
-    ];
+    ] : [];
     if (useArrows) {
       return j.variableDeclaration('const', [
         j.variableDeclarator(
@@ -298,6 +299,7 @@ module.exports = function(file, api, options) {
       console.warn(`Unable to destructure ${name} props.`);
     }
 
+    const hasThisDotProps = j(renderBody).find(j.MemberExpression, THIS_PROPS).length > 0;
     replaceThisProps(renderBody);
 
     if (useArrows) {
@@ -306,7 +308,8 @@ module.exports = function(file, api, options) {
           name,
           renderBody,
           propsTypeAnnotation,
-          destructure
+          destructure,
+          hasThisDotProps
         ),
         ...buildStatics(name, statics)
       ];
@@ -316,7 +319,8 @@ module.exports = function(file, api, options) {
           name,
           renderBody,
           propsTypeAnnotation,
-          destructure
+          destructure,
+          hasThisDotProps
         ),
         ...buildStatics(name, statics)
       ];

--- a/transforms/utils/ReactUtils.js
+++ b/transforms/utils/ReactUtils.js
@@ -123,6 +123,20 @@ module.exports = function(j) {
       : undefined;
   };
 
+  const removeUnusedSuperClassImport = (path, file, superClassName) => {
+    if (path.find(j.Identifier, {
+      type: 'Identifier',
+      name: superClassName
+    }).length === 0) {
+      file.find(j.ImportSpecifier, {
+        type: 'ImportSpecifier',
+        imported: {
+          type: 'Identifier',
+          name: superClassName,
+        }
+      }).remove();
+    }
+  };
 
   const findReactES6ClassDeclarationByParent = (path, parentClassName) => {
     const componentImport = findReactComponentNameByParent(path, parentClassName);
@@ -282,6 +296,7 @@ module.exports = function(j) {
     hasModule,
     hasReact,
     isMixinProperty,
+    removeUnusedSuperClassImport,
 
     // "direct" methods
     findAllReactCreateClassCalls,


### PR DESCRIPTION
**case 1: Default exported classes**
When converting a class combined with a default export, to a pure component, you end up creating a syntax error. This is because you cannot combine the default keyword with a lexical declaration. This PR separates the declaration from the export in this case. 

**case 2: Unused super class import remains**
When converting to a pure functional component the old super class may have a named import that is no longer used. This should be removed.

**case 3: Props argument exists even if its never used**
