### PR TITLE
Update update-react-imports with early return

### DIFF
--- a/transforms/__testfixtures__/update-react-imports/react-type-default-export.input.js
+++ b/transforms/__testfixtures__/update-react-imports/react-type-default-export.input.js
@@ -1,0 +1,4 @@
+import type React from "react";
+import * as React from "react";
+
+<div>Hi</div>;

--- a/transforms/__testfixtures__/update-react-imports/react-type-default-export.output.js
+++ b/transforms/__testfixtures__/update-react-imports/react-type-default-export.output.js
@@ -1,0 +1,3 @@
+import type React from "react";
+
+<div>Hi</div>;

--- a/transforms/__tests__/update-react-imports-test.js
+++ b/transforms/__tests__/update-react-imports-test.js
@@ -18,6 +18,7 @@ const tests = [
   'react-basic-default-export-jsx-element-react-variable',
   'react-basic-default-export-jsx-element',
   'react-basic-default-export',
+  'react-type-default-export',
 ];
 
 jest.mock('../update-react-imports', () => {

--- a/transforms/update-react-imports.js
+++ b/transforms/update-react-imports.js
@@ -27,6 +27,7 @@ module.exports = function(file, api, options) {
     .filter(path => {
       return (
         path.value.specifiers.length > 0 &&
+        path.value.importKind === 'value' &&
         path.value.specifiers.some(
           specifier => specifier.local.name === 'React',
         )
@@ -34,7 +35,9 @@ module.exports = function(file, api, options) {
     });
 
   if (reactImportPath.size() > 1) {
-    throw Error('There should only be one React import. Please remove the duplicate import and try again.');
+    throw Error(
+      'There should only be one React import. Please remove the duplicate import and try again.',
+    );
   }
 
   if (reactImportPath.size() === 0) {
@@ -95,6 +98,9 @@ module.exports = function(file, api, options) {
         } else {
           j(reactPath).remove();
         }
+      } else {
+        // nothing is transformed so we can return
+        return null;
       }
     }
     break;


### PR DESCRIPTION
Sometimes, `jscodeshift` will modify files that it touched even though the codemod may not have actually modified any code. Because `jscodeshift` sometimes doesn't play well with types, this sometimes leads to files being modified unintentionally in strange ways. This PR adds an early return if we know we aren't going to modify any react imports in `update-react-imports` to avoid these unintentional modifications.

This PR also fixes a bug where we treat `import type React from 'react'` the same as `import React from 'react'`.