### PR TITLE
Add name-default-component codemod

### DIFF
--- a/transforms/__testfixtures__/name-default-component/1-starts-with-number.input.js
+++ b/transforms/__testfixtures__/name-default-component/1-starts-with-number.input.js
@@ -1,0 +1,1 @@
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/1-starts-with-number.output.js
+++ b/transforms/__testfixtures__/name-default-component/1-starts-with-number.output.js
@@ -1,0 +1,1 @@
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/1-starts-with-number.output.js
+++ b/transforms/__testfixtures__/name-default-component/1-starts-with-number.output.js
@@ -1,1 +1,0 @@
-export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/existing-name-ignore.input.js
+++ b/transforms/__testfixtures__/name-default-component/existing-name-ignore.input.js
@@ -1,0 +1,4 @@
+const ExistingNameIgnoreInput = null;
+const ExistingNameIgnoreInputComponent = null;
+
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/existing-name-ignore.output.js
+++ b/transforms/__testfixtures__/name-default-component/existing-name-ignore.output.js
@@ -1,0 +1,4 @@
+const ExistingNameIgnoreInput = null;
+const ExistingNameIgnoreInputComponent = null;
+
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/existing-name-ignore.output.js
+++ b/transforms/__testfixtures__/name-default-component/existing-name-ignore.output.js
@@ -1,4 +1,0 @@
-const ExistingNameIgnoreInput = null;
-const ExistingNameIgnoreInputComponent = null;
-
-export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/existing-name.input.js
+++ b/transforms/__testfixtures__/name-default-component/existing-name.input.js
@@ -1,0 +1,7 @@
+const ExistingNameInput = null;
+
+function nested() {
+  const ExistingNameInputComponent = null;
+}
+
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/existing-name.output.js
+++ b/transforms/__testfixtures__/name-default-component/existing-name.output.js
@@ -1,0 +1,9 @@
+const ExistingNameInput = null;
+
+function nested() {
+  const ExistingNameInputComponent = null;
+}
+
+const ExistingNameInputComponent = () => <div>Anonymous function</div>;
+
+export default ExistingNameInputComponent;

--- a/transforms/__testfixtures__/name-default-component/function-component-2.input.js
+++ b/transforms/__testfixtures__/name-default-component/function-component-2.input.js
@@ -1,0 +1,1 @@
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/function-component-2.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-component-2.output.js
@@ -1,0 +1,2 @@
+const FunctionComponent2Input = () => <div>Anonymous function</div>;
+export default FunctionComponent2Input;

--- a/transforms/__testfixtures__/name-default-component/function-component-ignore.input.js
+++ b/transforms/__testfixtures__/name-default-component/function-component-ignore.input.js
@@ -1,7 +1,7 @@
 export default () => {
   const x = 'y';
   if (true) {
-    return <div>Anonymous function</div>;
+    return '';
   }
   return null;
 };

--- a/transforms/__testfixtures__/name-default-component/function-component-ignore.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-component-ignore.output.js
@@ -1,7 +1,7 @@
 export default () => {
   const x = 'y';
   if (true) {
-    return <div>Anonymous function</div>;
+    return '';
   }
   return null;
 };

--- a/transforms/__testfixtures__/name-default-component/function-component-ignore.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-component-ignore.output.js
@@ -1,7 +1,0 @@
-export default () => {
-  const x = 'y';
-  if (true) {
-    return '';
-  }
-  return null;
-};

--- a/transforms/__testfixtures__/name-default-component/function-component.input.js
+++ b/transforms/__testfixtures__/name-default-component/function-component.input.js
@@ -1,0 +1,3 @@
+export default () => {
+  return <div>Anonymous function</div>;
+};

--- a/transforms/__testfixtures__/name-default-component/function-component.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-component.output.js
@@ -1,5 +1,9 @@
-const FunctionComponent = () => {
-  return <div>Anonymous function</div>;
+const FunctionComponentInput = () => {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
 };
 
-export default FunctionComponent;
+export default FunctionComponentInput;

--- a/transforms/__testfixtures__/name-default-component/function-component.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-component.output.js
@@ -1,0 +1,5 @@
+const FunctionComponent = () => {
+  return <div>Anonymous function</div>;
+};
+
+export default FunctionComponent;

--- a/transforms/__testfixtures__/name-default-component/function-expression-ignore.input.js
+++ b/transforms/__testfixtures__/name-default-component/function-expression-ignore.input.js
@@ -1,0 +1,7 @@
+export default function Name() {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
+}

--- a/transforms/__testfixtures__/name-default-component/function-expression-ignore.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-expression-ignore.output.js
@@ -1,7 +1,0 @@
-export default function Name() {
-  const x = 'y';
-  if (true) {
-    return <div>Anonymous function</div>;
-  }
-  return null;
-}

--- a/transforms/__testfixtures__/name-default-component/function-expression-ignore.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-expression-ignore.output.js
@@ -1,0 +1,7 @@
+export default function Name() {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
+}

--- a/transforms/__testfixtures__/name-default-component/function-expression.input.js
+++ b/transforms/__testfixtures__/name-default-component/function-expression.input.js
@@ -1,0 +1,7 @@
+export default function () {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
+}

--- a/transforms/__testfixtures__/name-default-component/function-expression.output.js
+++ b/transforms/__testfixtures__/name-default-component/function-expression.output.js
@@ -1,0 +1,7 @@
+export default function FunctionExpressionInput() {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
+}

--- a/transforms/__testfixtures__/name-default-component/special-ch@racter.input.js
+++ b/transforms/__testfixtures__/name-default-component/special-ch@racter.input.js
@@ -1,0 +1,1 @@
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/special-ch@racter.output.js
+++ b/transforms/__testfixtures__/name-default-component/special-ch@racter.output.js
@@ -1,0 +1,1 @@
+export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/special-ch@racter.output.js
+++ b/transforms/__testfixtures__/name-default-component/special-ch@racter.output.js
@@ -1,1 +1,0 @@
-export default () => <div>Anonymous function</div>;

--- a/transforms/__testfixtures__/name-default-component/typescript/function-expression.input.js
+++ b/transforms/__testfixtures__/name-default-component/typescript/function-expression.input.js
@@ -1,0 +1,7 @@
+export default function (): JSX.Element {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
+}

--- a/transforms/__testfixtures__/name-default-component/typescript/function-expression.output.js
+++ b/transforms/__testfixtures__/name-default-component/typescript/function-expression.output.js
@@ -1,0 +1,7 @@
+export default function FunctionExpressionInput(): JSX.Element {
+  const x = 'y';
+  if (true) {
+    return <div>Anonymous function</div>;
+  }
+  return null;
+}

--- a/transforms/__tests__/name-default-component-test.js
+++ b/transforms/__tests__/name-default-component-test.js
@@ -12,6 +12,10 @@ const defineTest = require('jscodeshift/dist/testUtils').defineTest;
 
 const tests = [
   'function-component',
+  'function-component-2',
+  'function-component-ignore',
+  '1-starts-with-number',
+  'special-ch@racter',
 ];
 
 describe('name-default-component', () => {
@@ -31,7 +35,7 @@ describe('name-default-component', () => {
       jest.resetModules();
     });
 
-    tests.forEach(test =>
+    tests.forEach((test) =>
       defineTest(
         __dirname,
         'name-default-component',

--- a/transforms/__tests__/name-default-component-test.js
+++ b/transforms/__tests__/name-default-component-test.js
@@ -14,6 +14,8 @@ const tests = [
   'function-component',
   'function-component-2',
   'function-component-ignore',
+  'function-expression',
+  'function-expression-ignore',
   'existing-name',
   'existing-name-ignore',
   '1-starts-with-number',

--- a/transforms/__tests__/name-default-component-test.js
+++ b/transforms/__tests__/name-default-component-test.js
@@ -14,6 +14,8 @@ const tests = [
   'function-component',
   'function-component-2',
   'function-component-ignore',
+  'existing-name',
+  'existing-name-ignore',
   '1-starts-with-number',
   'special-ch@racter',
 ];

--- a/transforms/__tests__/name-default-component-test.js
+++ b/transforms/__tests__/name-default-component-test.js
@@ -20,6 +20,7 @@ const tests = [
   'existing-name-ignore',
   '1-starts-with-number',
   'special-ch@racter',
+  'typescript/function-expression',
 ];
 
 describe('name-default-component', () => {

--- a/transforms/__tests__/name-default-component-test.js
+++ b/transforms/__tests__/name-default-component-test.js
@@ -20,10 +20,36 @@ const tests = [
   'existing-name-ignore',
   '1-starts-with-number',
   'special-ch@racter',
-  'typescript/function-expression',
+  'typescript/function-expression', // Also works for Flow
 ];
 
 describe('name-default-component', () => {
+  describe('flow', () => {
+    beforeEach(() => {
+      jest.mock('../name-default-component', () => {
+        return Object.assign(
+          require.requireActual('../name-default-component'),
+          {
+            parser: 'flow',
+          }
+        );
+      });
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    tests.forEach((test) =>
+      defineTest(
+        __dirname,
+        'name-default-component',
+        null,
+        `name-default-component/${test}`
+      )
+    );
+  });
+
   describe('typescript', () => {
     beforeEach(() => {
       jest.mock('../name-default-component', () => {

--- a/transforms/__tests__/name-default-component-test.js
+++ b/transforms/__tests__/name-default-component-test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+const tests = [
+  'function-component',
+];
+
+describe('name-default-component', () => {
+  describe('typescript', () => {
+    beforeEach(() => {
+      jest.mock('../name-default-component', () => {
+        return Object.assign(
+          require.requireActual('../name-default-component'),
+          {
+            parser: 'tsx',
+          }
+        );
+      });
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    tests.forEach(test =>
+      defineTest(
+        __dirname,
+        'name-default-component',
+        null,
+        `name-default-component/${test}`
+      )
+    );
+  });
+});

--- a/transforms/name-default-component.js
+++ b/transforms/name-default-component.js
@@ -27,6 +27,8 @@ module.exports = (file, api, options) => {
   };
   const root = j(file.source);
 
+  let hasModifications;
+
   const returnsJSX = (node) =>
     node.type === 'JSXElement' ||
     (node.type === 'BlockStatement' &&
@@ -77,6 +79,8 @@ module.exports = (file, api, options) => {
       name += 'Component';
     }
 
+    hasModifications = true;
+
     if (isArrowFunction) {
       path.insertBefore(
         j.variableDeclaration('const', [
@@ -93,5 +97,5 @@ module.exports = (file, api, options) => {
 
   root.find(j.ExportDefaultDeclaration).forEach(nameFunctionComponent);
 
-  return root.toSource(printOptions);
+  return hasModifications ? root.toSource(printOptions) : null;
 };

--- a/transforms/name-default-component.js
+++ b/transforms/name-default-component.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const printOptions = options.printOptions || {
+    quote: 'single',
+    trailingComma: true,
+  };
+  const root = j(file.source);
+
+  const hasArrowFunctionWithJSX = (node) =>
+    node.type === 'ArrowFunctionExpression' &&
+    node.body.type === 'BlockStatement' &&
+    node.body.body.length === 1 &&
+    node.body.body[0].type === 'ReturnStatement' &&
+    node.body.body[0].argument &&
+    node.body.body[0].argument.type === 'JSXElement';
+
+  const nameFunctionComponent = (path) => {
+    const node = path.value;
+    const isUnnamedArrowFunction =
+      node.declaration && hasArrowFunctionWithJSX(node.declaration);
+
+    if (isUnnamedArrowFunction) {
+      path.insertBefore(
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.identifier('FunctionComponent'),
+            node.declaration
+          ),
+        ])
+      );
+
+      node.declaration = j.identifier('FunctionComponent');
+    }
+  };
+
+  root.find(j.ExportDefaultDeclaration).forEach(nameFunctionComponent);
+
+  return root.toSource(printOptions);
+};

--- a/transforms/name-default-component.js
+++ b/transforms/name-default-component.js
@@ -8,6 +8,19 @@
 
 'use strict';
 
+const { basename, extname } = require('path');
+
+const camelCase = (value) => {
+  const val = value.replace(/[-_\s.]+(.)?/g, (match, chr) =>
+    chr ? chr.toUpperCase() : ''
+  );
+  return val.substr(0, 1).toUpperCase() + val.substr(1);
+};
+
+const isValidIdentifier = (value) => /^[a-zA-ZÀ-ÿ][0-9a-zA-ZÀ-ÿ]+$/.test(value);
+
+const isArrowFunction = (node) => node.type === 'ArrowFunctionExpression';
+
 module.exports = (file, api, options) => {
   const j = api.jscodeshift;
   const printOptions = options.printOptions || {
@@ -16,31 +29,42 @@ module.exports = (file, api, options) => {
   };
   const root = j(file.source);
 
-  const hasArrowFunctionWithJSX = (node) =>
-    node.type === 'ArrowFunctionExpression' &&
-    node.body.type === 'BlockStatement' &&
-    node.body.body.length === 1 &&
-    node.body.body[0].type === 'ReturnStatement' &&
-    node.body.body[0].argument &&
-    node.body.body[0].argument.type === 'JSXElement';
+  const returnsJSX = (node) =>
+    node.type === 'JSXElement' ||
+    (node.type === 'BlockStatement' &&
+      j(node)
+        .find(j.ReturnStatement)
+        .some(
+          (path) =>
+            path.value.argument && path.value.argument.type === 'JSXElement'
+        ));
 
   const nameFunctionComponent = (path) => {
     const node = path.value;
     const isUnnamedArrowFunction =
-      node.declaration && hasArrowFunctionWithJSX(node.declaration);
+      node.declaration &&
+      isArrowFunction(node.declaration) &&
+      returnsJSX(node.declaration.body);
 
-    if (isUnnamedArrowFunction) {
-      path.insertBefore(
-        j.variableDeclaration('const', [
-          j.variableDeclarator(
-            j.identifier('FunctionComponent'),
-            node.declaration
-          ),
-        ])
-      );
-
-      node.declaration = j.identifier('FunctionComponent');
+    if (!isUnnamedArrowFunction) {
+      return;
     }
+
+    const fileName = basename(file.path, extname(file.path));
+    const name = camelCase(fileName);
+
+    // If the generated name looks off, don't set a name for this component
+    if (!isValidIdentifier(name)) {
+      return;
+    }
+
+    path.insertBefore(
+      j.variableDeclaration('const', [
+        j.variableDeclarator(j.identifier(name), node.declaration),
+      ])
+    );
+
+    node.declaration = j.identifier(name);
   };
 
   root.find(j.ExportDefaultDeclaration).forEach(nameFunctionComponent);


### PR DESCRIPTION
**Note:** The codemod name is a wip

A codemod to add a camel cased name based on the file to anonymous functions and arrow functions. If the name already exists it appends `Component` to the name. Check the test cases to see the accepted cases and exceptions.

The main purpose for the change described above is to have an easier migration of components to support Fast Refresh.

Class components and `create-react-class` aren't the target of this codemod as it won't make a difference for Fast Refresh.


TODO: update readme