### PR TITLE
fix: spawn `jscodeshift` cli using node

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,7 @@ const chalk = require('chalk');
 const isGitClean = require('is-git-clean');
 
 const transformerDirectory = path.join(__dirname, '../', 'transforms');
-const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
+const jscodeshiftExecutable = require.resolve('jscodeshift/bin/jscodeshift.js');
 
 function checkGitStatus(force) {
   let clean = false;
@@ -113,7 +113,7 @@ function runTransform({ files, flags, parser, transformer, answers }) {
 
   console.log(`Executing command: jscodeshift ${args.join(' ')}`);
 
-  const result = execa.sync(jscodeshiftExecutable, args, {
+  const result = execa.sync('node', [jscodeshiftExecutable, ...args], {
     stdio: 'inherit',
     stripEof: false
   });


### PR DESCRIPTION
**What's the problem this PR addresses?**

`react-codemod` tries to spawn sh files on Windows by spawning `node_modules/.bin/jscodeshift`

**How did you fix it?**

Resolve the JS CLI directly and spawn it using node