### PR TITLE
Don't rely on the .bin folder

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,7 @@ const chalk = require('chalk');
 const isGitClean = require('is-git-clean');
 
 const transformerDirectory = path.join(__dirname, '../', 'transforms');
-const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
+const jscodeshiftExecutable = require.resolve('jscodeshift/bin/jscodeshift');
 
 function checkGitStatus(force) {
   let clean = false;


### PR DESCRIPTION
The .bin folder isn't always guaranteed (it's an implementation detail that makes it easier for some package managers to add all relevant binaries to the PATH, but other approaches exist). Instead, packages should prefer accessing the binaries themselves from the path they list.

Fixes `yarn dlx react-codemod rename-unsafe-lifecycles`