### PR TITLE
Add support for superTypes Flow annotation

### DIFF
--- a/transforms/__testfixtures__/pure-component.input.js
+++ b/transforms/__testfixtures__/pure-component.input.js
@@ -83,4 +83,10 @@ class PureWithPropTypes2 extends React.Component {
   }
 }
 
+class PureWithPropTypes3 extends React.Component<Props> {
+  render() {
+    return <div>{this.props.foo}</div>;
+  }
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/__testfixtures__/pure-component.output.js
+++ b/transforms/__testfixtures__/pure-component.output.js
@@ -70,4 +70,8 @@ function PureWithPropTypes2(props: { foo: string }) {
 
 PureWithPropTypes2.propTypes = { foo: React.PropTypes.string };
 
+function PureWithPropTypes3(props: Props) {
+  return <div>{props.foo}</div>;
+}
+
 var A = props => <div className={props.foo} />;

--- a/transforms/pure-component.js
+++ b/transforms/pure-component.js
@@ -292,6 +292,7 @@ module.exports = function(file, api, options) {
     const renderMethod = p.value.body.body.filter(isRenderMethod)[0];
     const renderBody = renderMethod.value.body;
     const propsTypeAnnotation = findPropsTypeAnnotation(p.value.body.body);
+    const superTypeAnnotation = p.node.superTypeParameters && p.node.superTypeParameters.params[0]
     const statics = p.value.body.body.filter(isStaticProperty);
     const destructure = destructuringEnabled && canDestructure(j(renderMethod));
 
@@ -307,7 +308,7 @@ module.exports = function(file, api, options) {
         buildPureComponentArrowFunction(
           name,
           renderBody,
-          propsTypeAnnotation,
+          propsTypeAnnotation || superTypeAnnotation,
           destructure,
           hasThisDotProps
         ),
@@ -318,7 +319,7 @@ module.exports = function(file, api, options) {
         buildPureComponentFunction(
           name,
           renderBody,
-          propsTypeAnnotation,
+          propsTypeAnnotation || superTypeAnnotation,
           destructure,
           hasThisDotProps
         ),


### PR DESCRIPTION
It could be interesting to add support for superType annotations of
Flow. It is quite common in many projects and the transformation is
simple.