### PR TITLE
Update license in update-react-imports.js

### DIFF
--- a/transforms/update-react-imports.js
+++ b/transforms/update-react-imports.js
@@ -1,7 +1,9 @@
 /**
- * (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+ * Copyright 2015-present, Facebook, Inc.
  *
- * @format
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
  */
 
 'use strict';


### PR DESCRIPTION
I assume this is accidental but given that this is an MIT-licensed repository all files under it should also be MIT no?