### PR TITLE
Use named components for type imports in update-react-imports

### DIFF
--- a/transforms/__testfixtures__/update-react-imports/typescript/preserve-types-default.tsx.output.js
+++ b/transforms/__testfixtures__/update-react-imports/typescript/preserve-types-default.tsx.output.js
@@ -1,5 +1,5 @@
-import * as React from 'react';
+import { FunctionComponent } from 'react';
 
-const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
+const App: FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>
 );


### PR DESCRIPTION
Fixes #283.

Previously running update-react-imports against

```tsx
import React from 'react';

const App: React.FunctionComponent<{ message: string }> = ({ message }) => ();
```

produced the following output:

```tsx
import * as React from 'react';

const App: React.FunctionComponent<{ message: string }> = ({ message }) => ();
```

Note that types are not converted to be named exports like when React.BLAH values are used, usage in types still gets  plucked off the namespace object. This PR applies the fix documented [here](https://github.com/reactjs/react-codemod/issues/283#issuecomment-814884712), so now it compiles to:

```ts
import { FunctionComponent } from 'react';

const App: FunctionComponent<{ message: string }> = ({ message }) => ();
```
