### PR TITLE
feat(cli): Support passing class flags on CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -295,39 +295,40 @@ function run() {
         type: 'confirm',
         name: 'classFlow',
         when: answers => {
-          return cli.input[0] === 'class' || answers.transformer === 'class';
+          console.log(typeof cli.flags.classFlow, cli.flags.classFlow);
+          return (cli.input[0] === 'class' || answers.transformer === 'class') && !cli.flags.classFlow;
         },
         message: 'Generate Flow annotations from propTypes?',
-        default: true
+        default: 'classFlow' in cli.flags ? Boolean(cli.flags.classFlow) : true,
       },
       {
         type: 'confirm',
         name: 'classRemoveRuntimePropTypes',
         when: answers => {
-          return answers.classFlow === true;
+          return answers.classFlow === true && !cli.flags.classRemoveRuntimePropTypes;
         },
         message: 'Remove runtime PropTypes?',
-        default: false
+        default: 'classRemoveRuntimePropTypes' in cli.flags ? Boolean(cli.flags.classRemoveRuntimePropTypes) : false
       },
       {
         type: 'confirm',
         name: 'classPureComponent',
         when: answers => {
-          return cli.input[0] === 'class' || answers.transformer === 'class';
+          return (cli.input[0] === 'class' || answers.transformer === 'class') && !cli.flags.classPureComponent;
         },
         message:
           'replace react-addons-pure-render-mixin with React.PureComponent?',
-        default: true
+        default: 'classPureComponent' in cli.flags ? Boolean(cli.flags.classPureComponent) : true,
       },
       {
         type: 'input',
         name: 'classMixinModuleName',
         when: answers => {
-          return answers.classPureComponent === true;
+          return answers.classPureComponent === true && !cli.flags.classMixinModuleName;
         },
         // validate: () =>
         message: 'What module exports this mixin?',
-        default: 'react-addons-pure-render-mixin',
+        default: 'classMixinModuleName' in cli.flags ? cli.flags.classMixinModuleName : 'react-addons-pure-render-mixin',
         filter: x => x.trim()
       },
       // if transformer === 'pure-render-mixin'


### PR DESCRIPTION
While working on transforming our legacy codebase I'm finding that we have hundreds of files that are not completely converted and need additional processing. I added react-codemod as a starting point to go from createReactClass -> React.createClass -> class extends React.Component, which is in the middle of our codemod stack. I was able to use the class transform in isolation running directly from in node and filling in the options/jscodeshiftapi/etc. Unfortunately this doesn't work for all files. I found many issues with jscodeshift getting into infinite loops that did not appear when invoking react-codemod from the terminal.

The problem with invoking from the terminal in node via something like `execSync` is that it uses inquirer to be interactive. This PR makes it so that all class options can be specified on the terminal.

Here is an example of what the command I'm running looks like now:

```bash
npx react-codemod class /home/tim/netflix/tmp.jsx --force --parser=babel --classFlow=false --classRemoveRuntimePropTypes=false --classPureComponent=false

 OKK /home/tim/netflix/tmp.jsx
All done. 
Results: 
0 errors
0 unmodified
0 skipped
1 ok

```