### PR TITLE
fix(class): history.replaceState member expression

### DIFF
--- a/transforms/class.js
+++ b/transforms/class.js
@@ -176,8 +176,15 @@ module.exports = (file, api, options) => {
               path.parentPath &&
               path.parentPath.value &&
               path.parentPath.value.object &&
-              path.parentPath.value.object.name &&
-              path.parentPath.value.object.name === 'history'
+              (
+                // First check if history is the top level
+                path.parentPath.value.object.name &&
+                path.parentPath.value.object.name === 'history' ||
+
+                // Or is it part of a memberexpression?
+                path.parentPath.value.object.property &&
+                path.parentPath.value.object.property.name === 'history'
+              )
             ) {
               correctContext = false;
             }


### PR DESCRIPTION
In our code we have the following:

```js
                this.context.history.replaceState(
```

The deprecated APIs check only looks for `history.replaceState`. This fix makes the check more robust, by taking into account member expression types.