### PR TITLE
docs: add prop-types-typescript codemod

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ npx codemod react/pure-render-mixin --target <path>
    namespaced name for the mixin. `mixins: [React.addons.PureRenderMixin]` will
    not currently work.
 
+#### `prop-types-typescript`
+
+Converts React PropTypes to TypeScript types.
+
+- Supports function and class components
+- Supports `static propTypes` declarations on class components
+- Supports `forwardRef`s
+- Supports files with multiple components
+- Copies JSDoc comments to the generated TypeScript types
+- Option to remove or preserve PropTypes after converting to TS
+
+```sh
+npx codemod react/prop-types-typescript --target <path>
+```
+
 #### `React-PropTypes-to-prop-types`
 
 Replaces `React.PropTypes` references with `prop-types` and adds the appropriate `import` or `require` statement. This codemod is intended for React 15.5+.


### PR DESCRIPTION
Adds [prop-types-typescript](https://codemod.com/registry/react-prop-types-typescript) codemod to readme.

Other docs that should be updated: [migration guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#codemods) (href for `prop-types-typescript` pointing to `/TODO`.