### PR TITLE
fix(remove-forward-ref): mark ref as optional in type intersections

### DIFF
--- a/transforms/__testfixtures__/remove-forward-ref/typescript/props-type-literal.output.js
+++ b/transforms/__testfixtures__/remove-forward-ref/typescript/props-type-literal.output.js
@@ -3,7 +3,7 @@ const MyComponent = function Component(
         ref: myRef,
         ...myProps
     }: { a: 1 } & {
-        ref: React.RefObject<unknown>
+        ref?: React.RefObject<unknown>
     }
 ) {
     return null;

--- a/transforms/__testfixtures__/remove-forward-ref/typescript/type-arguments-custom-names.output.js
+++ b/transforms/__testfixtures__/remove-forward-ref/typescript/type-arguments-custom-names.output.js
@@ -3,7 +3,7 @@ const MyComponent = function Component(
     ref: myRef,
     ...myProps
   }: Props & {
-    ref: React.RefObject<HTMLButtonElement>
+    ref?: React.RefObject<HTMLButtonElement>
   }
 ) {
   return null;

--- a/transforms/__testfixtures__/remove-forward-ref/typescript/type-arguments-type-literals.output.js
+++ b/transforms/__testfixtures__/remove-forward-ref/typescript/type-arguments-type-literals.output.js
@@ -3,7 +3,7 @@ const MyInput = (
     ref,
     ...props
   }: { a: string } & {
-    ref: React.RefObject<RefValueType>
+    ref?: React.RefObject<RefValueType>
   }
 ) => {
   return null;

--- a/transforms/__testfixtures__/remove-forward-ref/typescript/type-arguments.output.js
+++ b/transforms/__testfixtures__/remove-forward-ref/typescript/type-arguments.output.js
@@ -5,7 +5,7 @@ const MyInput = (
     ref,
     ...props
   }: Props & {
-    ref: React.RefObject<HTMLInputElement>
+    ref?: React.RefObject<HTMLInputElement>
   }
 ) => {
   return null;

--- a/transforms/remove-forward-ref.ts
+++ b/transforms/remove-forward-ref.ts
@@ -22,6 +22,7 @@ const buildPropsAndRefIntersectionTypeAnnotation = (
       j.tsTypeLiteral([
         j.tsPropertySignature.from({
           key: j.identifier('ref'),
+          optional: true,
           typeAnnotation: j.tsTypeAnnotation(
             j.tsTypeReference.from({
               typeName: j.tsQualifiedName(


### PR DESCRIPTION
The codemod now generates `type & { ref?: RefType }` instead of `type & { ref: RefType }` to correctly reflect that [refs are optional](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0257ad63cd2d934b3fde65eca98f96452dc40847/types/react/index.d.ts#L292).

Otherwise, code like this:

```tsx
const VolumeIcon = React.forwardRef<
    React.ElementRef<typeof Svg>,
    React.ComponentPropsWithRef<typeof Svg>
>(({ width = "20", height = "20", ...props }, ref) => { ... }

<VolumeIcon /> // ← works
```

gets code-modded into code like this:

```tsx
const VolumeIcon = ({
    ref,
    width = "20",
    height = "20",
    ...props
}: React.ComponentPropsWithRef<typeof Svg> & {
    ref: React.RefObject<React.ElementRef<typeof Svg>>;
}) => { ... }

<VolumeIcon /> // ← fails with `Property 'ref' is missing in type '{}' but required in type '{ ref: RefObject<SVGSVGElement>; }'`
```

and requires manual fixing.